### PR TITLE
Documentation: Refactor installation and contribution guides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,29 +1,16 @@
-.. |gitlab-badge| image:: https://img.shields.io/badge/gitlab-repo-red?style=flat&logo=gitlab
-  :target: https://gitlab.dwd.de/ku/libraries/pyku
-  :alt: GitLab Repository
-
 .. |github-badge| image:: https://img.shields.io/badge/github-repo-blue?style=flat&logo=github
   :target: https://github.com/deutscherwetterdienst/pyku
   :alt: GitHub Repository
 
-.. |documentation-badge| image:: https://img.shields.io/badge/Documentation-View%20on%20GitLab-green
-  :target: http://ku.pages.dwd.de/libraries/pyku/
-  :alt: Documentation
-
-.. |issue-badge| image:: https://img.shields.io/badge/Issues-View%20on%20GitLab-red
-  :target: https://gitlab.dwd.de/ku/libraries/pyku/-/issues
-  :alt: GitLab Issues
+.. |docs-badge| image:: https://img.shields.io/badge/docs-gh--pages-blue?style=flat&logo=github
+   :target: https://deutscherwetterdienst.github.io/pyku/
+   :alt: Documentation Status
 
 .. |issue-github-badge| image:: https://img.shields.io/badge/Issues-View%20on%20GitHub-blue
   :target: https://github.com/deutscherwetterdienst/pyku/issues
   :alt: GitHub Issues
 
-
-|gitlab-badge| |github-badge|
-
-|documentation-badge|
-
-|issue-badge| |issue-github-badge|
+|github-badge| |docs-badge| |issue-github-badge|
 
 Comprehensive climate data handling with Xarray
 -----------------------------------------------

--- a/doc/contribute/developers.rst
+++ b/doc/contribute/developers.rst
@@ -15,7 +15,7 @@ Alternatively use :class:`geopandas.GeoDataFrame` for the input and outputs
 where polyons or point data are needed.
 
 Write independent functions for simplicity, and only use objects where
-necessary
+necessary.
 
 Developer installation
 ----------------------
@@ -34,7 +34,7 @@ First, create a new virtual environment and install pyku:
 
    source yourvenv/bin/activate
 
-Clone and ``cd`` to the *pyku* directory:
+Create a fork, a feature branch, clone and ``cd`` to the pyku directory:
 
 .. code:: bash
 

--- a/doc/contribute/developers.rst
+++ b/doc/contribute/developers.rst
@@ -20,7 +20,7 @@ necessary
 Developer installation
 ----------------------
 
-First, create a new virtual environment and install*pyku:
+First, create a new virtual environment and install pyku:
 
 .. code:: bash
 
@@ -38,7 +38,7 @@ Clone and ``cd`` to the *pyku* directory:
 
 .. code:: bash
 
-   git clone https://gitlab.dwd.de/ku/libraries/pyku/
+   git clone https://github.com/deutscherwetterdienst/pyku
    cd pyku
 
 .. tip::
@@ -75,24 +75,6 @@ part of *pyku* that you are working on with ``importlib``:
 
    importlib.reload(meta)
    meta.get_frequency(ds, dtype='freqstr')
-
-.. warning::
-
-   How to debug with the xarray data accessor for debuggin is an open question.
-   That is it still needs to be clarified how to reload in jupyter if you use:
-
-   .. code:: python
-
-      ds.pyku.get_frequency(dtype='freqstr')
-
-   Instead you will can use for debugging:
-
-   .. code:: python
-
-      importlib.reload(meta)
-      meta.get_frequency(ds, dtype='freqstr')
-
-   If you know the solution, dont hesitate to let us know or update this doc.
 
 Doctests
 --------

--- a/doc/contribute/maintainers.rst
+++ b/doc/contribute/maintainers.rst
@@ -2,39 +2,23 @@ Maintainers
 ===========
 
 Maintainers possess elevated permissions in comparison to developers and carry
-the crucial responsibility of upholding code integrity. Their duties encompass
-not only integrating merge requests into the master branch but also overseeing
-the creation of new releases. This pivotal role involves ensuring that the
-codebase remains cohesive and robust, aligning with project objectives and
-quality standards. Additionally, maintainers play a pivotal role in fostering
-collaboration among team members, facilitating efficient code reviews, and
-resolving conflicts to uphold the overall health of the software development
-process.
+the responsibility of upholding code integrity. Their duties encompass not only
+integrating merge requests into the master branch but also overseeing the
+creation of new releases. This role involves ensuring that the codebase remains
+cohesive and robust, aligning with project objectives and quality standards.
+Additionally, maintainers play a pivotal role in fostering collaboration among
+team members, facilitating efficient code reviews, and resolving conflicts to
+uphold the overall health of the software development process.
 
-KU color map
-------------
-
-The official DWD color map is integrated in pyku. Updates of the colormaps are
-performed manually from the `official colormap repository
-<https://gitlab.dwd.de/ku/libraries/ku_colors>`_. To do this, the file
-``pyku/etc/base_colors.yaml`` in the pyku repository must be overwritten by the
-file ``base_colors.yaml`` from the `official colormap repository
-<https://gitlab.dwd.de/ku/libraries/ku_colors>`_.
-
-Merge request
+Pull request
 -------------
 
 Upon submission of a merge request, an automated pipeline is triggered to build
 and deploy the documentation, while also conducting doctests, unit tests and
-integration testing. It is imperative not to proceed with merging to the master
+integration testing. It is imperative not to proceed with merging to the main
 branch until the pipeline has completed successfully. The status of the
-pipeline can be monitored at the following link: `Pipeline Status
-<https://gitlab.dwd.de/ku/libraries/pyku/-/pipelines>`_.
-
-Once the pipeline has executed without errors, you may proceed to merge by
-clicking the designated button. At this juncture, conducting a thorough code
-review is highly encouraged before finalizing the merge, ensuring adherence to
-coding standards and promoting overall code quality.
+pipeline can be monitored in the action tab. Only once the pipeline has
+executed without errors may you proceed to merge.
 
 .. rubric:: Checklist
 
@@ -112,60 +96,4 @@ Now you can push the tag to the remote:
 
    git push --tags
 
-A new pipeline is triggered which deploys *pyku* to the ``pyku.stable``
-environment module for use in production. It also creates a python wheel which
-is then available in the `pypi registry set up on the KU gitlab server
-<https://gitlab.dwd.de/ku/pypi/-/packages>`_.
-
-.. rubric:: Create a new gitlab release
-
-Create a new gitlab release for the new tag under
-https://gitlab.dwd.de/ku/libraries/pyku/-/releases
-
-Copy the content of the ``CHANGELOG.rst``, reformat from rst to the Markdown.
-
-CI/CD Pipelines
----------------
-
-.. code:: bash
-
-   echo -n 'youpassword' | base64
-   eW91cGFzc3dvcmQ=
-
-To convert the password back, as is done in the pipeline:
-
-.. code:: bash
-
-   echo -n 'eW91cGFzc3dvcmQ=' | base64 --decode
-   youpassword
-
-.. rubric:: token for automated wheel deployment to to pypi registry
-
-The ``ku/pypi`` repository servers as a local pypi registry for automated
-deployment. At each release, the wheel is built and uploaded to the registry.
-The token for automated deployment of the wheel is located in the *pyku*
-repository under:
-
-.. code:: bash
-
-   cat .pypirc 
-   [distutils]
-   index-servers =
-       gitlab
-
-   [gitlab]
-   repository = https://gitlab.dwd.de/api/v4/projects/1719/packages/pypi
-   username = pypi
-   password = the_password
-
-The token is only valid for a limited time. Hence it must be renewed in the
-gitlab interface of the *pypi* repository at:
-
-https://gitlab.dwd.de/ku/pypi/-/settings/access_tokens
-
-The token should be created with the following permissions:
-
-* **Role**: ``developer``
-* **Scope**: ``api``
-
-Which then allows to write in the registry.
+A new pipeline is triggered which deploys the pyku documentation.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -3,9 +3,7 @@ Installation
 
 .. warning::
 
-   pyku is not yet available on PyPI. Installation via pip install pyku will
-   fail until the official release. Please install directly from the source
-   repository.
+   Pyku is not yet on PyPI, but we're working on it.
 
 To install pyku, ensure your system is properly configured. The following
 non-python dependencies are necessary:
@@ -19,38 +17,59 @@ non-python dependencies are necessary:
 To build the documentation, you will additionally need `pandoc
 <https://pandoc.org/>`_.
 
-Once these prerequisites are met, you can install the latest release of pyku
-using the command ``pip install``.
+Once these prerequisites are met, you can install the latest release of pyku.
 
-.. code:: bash
+.. using the command ``pip install``.
+..
+.. .. code:: bash
+..
+..    # Install the latest stable pyku release
+..    # --------------------------------------
+..
+..    pip install pyku
+..
+..    # Install extra dependencies to build documentation
+..    # -------------------------------------------------
+..
+..    pip install pyku[documentation]
 
-   # Install the latest stable pyku release
-   # --------------------------------------
+.. Upgrade
+.. -------
+..
+.. This command installs or updates to the latest version.
+..
+.. .. code:: bash
+..
+..    pip install pyku --upgrade
 
-   pip install pyku
+.. Pin version
+.. -----------
+..
+.. By specifying an exact version, it can also be used to downgrade pyku:
+..
+.. .. code:: bash
+..
+..    pip install pyku==v1.0.0
 
-   # Install extra dependencies to build documentation
-   # -------------------------------------------------
-
-   pip install pyku[documentation]
-
-Upgrade
--------
-
-This command installs or updates to the latest version.
-
-.. code:: bash
-
-   pip install pyku --upgrade
-
-Downgrade
----------
-
-By specifying an exact version, it can also be used to downgrade pyku:
-
-.. code:: bash
-
-   pip install pyku==v1.0.0
+.. Optional packages
+.. -----------------
+..
+.. To install the necessary packages for building the documentation, including all
+.. Sphinx dependencies and Jupyter, use this setup. These packages will be
+.. installed automatically, making it an excellent starting point.
+..
+.. .. code:: bash
+..
+..    pip install pyku[documentation]
+..
+.. Bindings to CDO should generally be avoided within the scope of pyku. However,
+.. there is one exception: a function required for derotating wind components in
+.. rotated model data. This functionality is isolated from the rest of the code
+.. and can be installed using:
+..
+.. .. code:: bash
+..
+..    pip install pyku[cdo_bindings]
 
 from master
 -----------
@@ -59,16 +78,28 @@ To install the current master from the repository:
 
 .. code:: bash
 
-   pip install git+https://https://github.com/DeutscherWetterdienst/pyku
+   pip install "pyku @ git+https://github.com/DeutscherWetterdienst/pyku"
+
+To install the dependencies to build the documentation:
+
+.. code:: bash
+
+   pip install "pyku[documentation] @ git+https://github.com/DeutscherWetterdienst/pyku"
 
 from source
 -----------
 
-To install from source you will need to clone the repository first.
+To install from source, clone the repository and run:
 
 .. code:: bash
 
    pip install .
+
+To install from source with the dependencies to build the documentation
+
+.. code:: bash
+
+   pip install ".[documentation]"
 
 for development
 ---------------
@@ -79,25 +110,12 @@ To install in development mode:
 
    pip install -e .
 
-Optional packages
------------------
-
-To install the necessary packages for building the documentation, including all
-Sphinx dependencies and Jupyter, use this setup. These packages will be
-installed automatically, making it an excellent starting point.
+To install in development mode with the dependencies to build the
+documentation:
 
 .. code:: bash
 
-   pip install pyku[documentation]
-
-Bindings to CDO should generally be avoided within the scope of pyku. However,
-there is one exception: a function required for derotating wind components in
-rotated model data. This functionality is isolated from the rest of the code
-and can be installed using:
-
-.. code:: bash
-
-   pip install pyku[cdo_bindings]
+   pip install -e ".[documentation]"
 
 Compiled dependencies
 ---------------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -86,6 +86,15 @@ To install the dependencies to build the documentation:
 
    pip install "pyku[documentation] @ git+https://github.com/DeutscherWetterdienst/pyku"
 
+pin version
+-----------
+
+To pin a version:
+
+.. code:: bash
+
+   pip install "pyku @ git+https://github.com/DeutscherWetterdienst/pyku@v1.0.0"
+
 from source
 -----------
 

--- a/doc/plugins/climate_indicators/new_indicators.rst
+++ b/doc/plugins/climate_indicators/new_indicators.rst
@@ -1,23 +1,43 @@
 Adding New Indicators
 =====================
 
-CLIX primarily uses functions available within the **xclim.indices** package. You can find their comprehensive documentation here: `xclim indices Documentation <https://xclim.readthedocs.io/en/stable/apidoc/xclim.indices.html>`_.
+CLIX primarily uses functions available within the **xclim.indices** package.
+You can find their comprehensive documentation here: `xclim indices
+Documentation
+<https://xclim.readthedocs.io/en/stable/apidoc/xclim.indices.html>`_.
 
-If you identify an essential indicator that is not yet implemented and is available in `xclim.indices`, please open a new issue on our GitHub repository: `pyku GitHub Issues <https://gitlab.dwd.de/ku/libraries/pyku/-/issues/>`_. When opening an issue, refer to the specific `xclim.indices` function and provide a clear definition of the new climate indicator you would like to see implemented.
+If you identify an essential indicator that is not yet implemented and is
+available in `xclim.indices`, please open a new issue on our GitHub repository:
+`pyku GitHub Issues <hhttps://github.com/deutscherwetterdienst/pyku/issues>`_.
+When opening an issue, refer to the specific `xclim.indices` function and
+provide a clear definition of the new climate indicator you would like to see
+implemented.
 
-For flexible integration of custom indicators not available through `xclim`, CLIX provides a mechanism to include them as functions within a centralized location. The `clix_custom_indicators.py` file serves this purpose as the entry point for individually defined indicators. To implement new indicators, the following instructions should be followed:
+For flexible integration of custom indicators not available through `xclim`,
+CLIX provides a mechanism to include them as functions within a centralized
+location. The `clix_custom_indicators.py` file serves this purpose as the entry
+point for individually defined indicators. To implement new indicators, the
+following instructions should be followed:
 
-* The function must accept at least one input ``xarray.DataArray``, defined as a mandatory argument.
+* The function must accept at least one input ``xarray.DataArray``, defined as
+  a mandatory argument.
 * The function's output must also be an ``xarray.DataArray``.
-* A complete docstring should be included for the function to aid in understanding the indicator's purpose and usage.
+* A complete docstring should be included for the function to aid in
+  understanding the indicator's purpose and usage.
 
-To ensure a consistent layout for the indicators, it can be helpful to review the indices defined in `xclim` and the `generic functions <https://xclim.readthedocs.io/en/stable/apidoc/xclim.indices.html#xclim-indices-generic-module>`_ that can be configured to address a broader set of problems.
+To ensure a consistent layout for the indicators, it can be helpful to review
+the indices defined in `xclim` and the `generic functions
+<https://xclim.readthedocs.io/en/stable/apidoc/xclim.indices.html#xclim-indices-generic-module>`_
+that can be configured to address a broader set of problems.
 
-Below is an example of a function within the `clix_custom_indicators.py` file and its integration within the `climate_indicators.yaml` file.
+Below is an example of a function within the `clix_custom_indicators.py` file
+and its integration within the `climate_indicators.yaml` file.
 
 **Example: Definition for a New Indicator (Potential Snow Days)**
 
-This example illustrates the definition of "Potential Snow Days" using a generic `xclim` function embedded as a Python wrapper, which is then linked within the YAML configuration file.
+This example illustrates the definition of "Potential Snow Days" using a
+generic `xclim` function embedded as a Python wrapper, which is then linked
+within the YAML configuration file.
 
 .. code-block:: python
 

--- a/doc/tutorials/polygons.ipynb
+++ b/doc/tutorials/polygons.ipynb
@@ -5,8 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# DWD polygons\n",
-    "\n",
+    "# Polygons"
    ]
   },
   {
@@ -364,9 +363,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "pyku_dev",
    "language": "python",
-   "name": "python3"
+   "name": "pyku_dev"
   },
   "language_info": {
    "codemirror_mode": {

--- a/doc/tutorials/polygons.ipynb
+++ b/doc/tutorials/polygons.ipynb
@@ -7,9 +7,6 @@
    "source": [
     "# DWD polygons\n",
     "\n",
-    "https://gitlab.dwd.de/ku/libraries/pyku/-/issues/58\n",
-    "\n",
-    "Currently, we invest excessive time searching for polygons without proper documentation of our sources. Moreover, the polygons utilized lack consistency across our products. Establishing standardized default polygons accessible, shareable, and usable via KU will streamline this process significantly."
    ]
   },
   {


### PR DESCRIPTION
## Description

This pull request updates the documentation:

* **Installation:** Removed GitLab and PyPI references; added installation steps directly from the GitHub repository
* **Content Cleanup:** Deleted obsolete documentation sections.
* **Style Standardization:** Applied an 80-character line limit to all `clix` documentation.