### PR TITLE
CI: Manual caching and workflow updates

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,0 +1,52 @@
+name: Manual cache update
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  LANGUAGE: "en_US:en"
+  LANG: "en_US"
+  LC_ALL: C
+  PYKU_DATA_DIR: ${{ github.workspace }}/pyku_cache
+  XDG_DATA_HOME: ${{ github.workspace }}/pyku_cache
+  CARTOPY_DATA_DIR: ${{ github.workspace }}/pyku_cache/cartopy
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install System Binaries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgeos-dev libudunits2-dev libhdf5-dev libnetcdf-dev libproj-dev pandoc
+
+      - name: Cache PYKU Data
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.PYKU_DATA_DIR }}
+          key: global-pyku-data
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build and Test
+        run: |
+          mkdir -p "$PYKU_DATA_DIR"
+          mkdir -p "$CARTOPY_DATA_DIR"
+          uv venv
+          source .venv/bin/activate
+          uv pip install --upgrade pip setuptools wheel cython nbstripout build
+          uv build
+          WHEEL_PATH=$(ls dist/*.whl)
+          uv pip install "$WHEEL_PATH"
+          python3 ./definitions/download_test_data.py

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -35,7 +35,7 @@ jobs:
           key: global-pyku-data
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v5
 
       - name: Build and Test
         run: |

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -35,7 +35,9 @@ jobs:
           key: global-pyku-data
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
 
       - name: Build and cache test data
         run: |

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,9 +1,6 @@
 name: Manual cache update
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 env:
@@ -22,6 +19,7 @@ permissions:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -23,12 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install System Binaries
+      - name: Install system binaries
         run: |
           sudo apt-get update
           sudo apt-get install -y libgeos-dev libudunits2-dev libhdf5-dev libnetcdf-dev libproj-dev pandoc
 
-      - name: Cache PYKU Data
+      - name: Cache pyku data
         uses: actions/cache@v5
         with:
           path: ${{ env.PYKU_DATA_DIR }}
@@ -37,7 +37,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Build and Test
+      - name: Build and cache test data
         run: |
           mkdir -p "$PYKU_DATA_DIR"
           mkdir -p "$CARTOPY_DATA_DIR"

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -35,7 +35,7 @@ jobs:
           key: global-pyku-data
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
 
       - name: Build and Test
         run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -76,7 +76,7 @@ jobs:
           ipython ./testing/check_notebooks_are_cleared.ipy
 
           python3 -m unittest discover -v -s ./testing -p "*_test.py"
-          sphinx-build -j 4 ./doc/ ./docs
+          sphinx-build -j 1 ./doc/ ./docs
 
       - name: Upload pages artifacts
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Inspect Hardware
+      - name: Inspect hardware
         run: |
           echo "CPU Details:"
           lscpu | grep -E '^Thread\(s\) per core|^Core\(s\) per socket|^CPU\(s\)'
@@ -44,12 +44,12 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Install System Binaries
+      - name: Install system binaries
         run: |
           sudo apt-get update
           sudo apt-get install -y libgeos-dev libudunits2-dev libhdf5-dev libnetcdf-dev libproj-dev pandoc
 
-      - name: Cache PYKU Data
+      - name: Cache pyku data
         uses: actions/cache@v5
         with:
           path: ${{ env.PYKU_DATA_DIR }}
@@ -58,7 +58,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Build and Test
+      - name: Build, test and generate documentation
         run: |
           mkdir -p "$PYKU_DATA_DIR"
           mkdir -p "$CARTOPY_DATA_DIR"
@@ -76,7 +76,7 @@ jobs:
           python3 -m unittest discover -v -s ./testing -p "*_test.py"
           sphinx-build -j 1 ./doc/ ./docs
 
-      - name: Upload Pages artifact
+      - name: Upload pages artifacts
         uses: actions/upload-pages-artifact@v4
         with:
           path: docs
@@ -89,6 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -44,7 +44,7 @@ jobs:
           key: global-pyku-data
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
 
       - name: Build and Test
         run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -56,7 +56,9 @@ jobs:
           key: global-pyku-data
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
 
       - name: Build, test and generate documentation
         run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -41,9 +41,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.PYKU_DATA_DIR }}
-          key: global-pyku-data-cache-${{ github.run_id }}
-          restore-keys: |
-            global-pyku-data-cache-
+          key: global-pyku-data
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -76,7 +76,7 @@ jobs:
           ipython ./testing/check_notebooks_are_cleared.ipy
 
           python3 -m unittest discover -v -s ./testing -p "*_test.py"
-          sphinx-build -j 1 ./doc/ ./docs
+          sphinx-build -j 4 ./doc/ ./docs
 
       - name: Upload pages artifacts
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -56,7 +56,7 @@ jobs:
           key: global-pyku-data
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v5
 
       - name: Build and Test
         run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -30,6 +30,18 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
+
+      - name: Inspect Hardware
+        run: |
+          echo "CPU Details:"
+          lscpu | grep -E '^Thread\(s\) per core|^Core\(s\) per socket|^CPU\(s\)'
+          echo "---"
+          echo "Memory Details:"
+          free -h
+          echo "---"
+          echo "Disk Space:"
+          df -h | grep '^/dev/'
+
       - uses: actions/checkout@v6
 
       - name: Install System Binaries

--- a/definitions/download_test_data.py
+++ b/definitions/download_test_data.py
@@ -1,4 +1,5 @@
 import pyku
 
 for id in pyku.list_test_data(include_aliases=False):
+    print(id)
     print(pyku.resources.get_test_data(id))

--- a/definitions/download_test_data.py
+++ b/definitions/download_test_data.py
@@ -1,0 +1,4 @@
+import pyku
+
+for id in pyku.list_test_data(include_aliases=False):
+    print(pyku.resources.get_test_data(id))


### PR DESCRIPTION
## Description
This PR introduces a manual caching pipeline.

### Key Changes
* **Caching:** Added a manual workflow on `main` to download and store pyku test data in the GitHub cache. Other pipelines should be able to see the cache. This was only tested on branches, but not on pull requests. We should be able to run the cache pipeline manually on main to speed up building the documentation.
* **Dependency updates:** Upgraded all GitHub Actions to their latest versions.
    * *Note:* `astral-sh/setup-uv@v7` now supports native `uv` caching; this is currently disabled.
* **Resource monitoring:** Added a step to log available **CPU** and **RAM** on the runner to assist with performance debugging.