### PR TITLE
Introducing Resource and Config Provider

### DIFF
--- a/doc/tutorials/polygons.ipynb
+++ b/doc/tutorials/polygons.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "## Download directory\n",
     "\n",
-    "Polygons are mostly downloaded on-the-fly. The download takes place only one time and the downloaded data are reused if the polygons are called twice. The download path can be shown with. If you set the environment variable ``PYKU_DATA_DIR``, the data will automatically be downloaded in that directory. If you do not set that environment variable, data are downloaded by default in the *standard* directory ``/home/kudev/.local/share/pyku``"
+    "Polygons are mostly downloaded on-the-fly. The download takes place only one time and the downloaded data are reused if the polygons are called twice. The download path can be shown with. If you set the environment variable ``PYKU_DATA_DIR``, the data will automatically be downloaded in that directory. If you do not set that environment variable, data are downloaded by default in the *standard* directory ``~/.local/share/pyku``. You can also overwrite the data_dir during runtime using ``pyku.PYKU_CONFIG.set(data_dir) = <your_new_data_dir>``, but there wont be any sanity checks that way, so the directory needs to exist and needs to have the right permissions set."
    ]
   },
   {
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "pyku.config"
+    "pyku.PYKU_CONFIG"
    ]
   },
   {

--- a/pyku/__init__.py
+++ b/pyku/__init__.py
@@ -2,18 +2,17 @@
 Package initializer
 """
 
-import os
-import tempfile
+import logging
+import warnings
+from importlib.metadata import (version as importlib_version,
+                                PackageNotFoundError)
+
 import xarray as xr
-from pathlib import Path
-import importlib
-import yaml
+
+from pyku.core import PYKU_RESOURCES, PYKU_CONFIG  # noqa
 
 # Set up the logger
 # -----------------
-
-import logging
-import warnings
 
 # Here the logger must be set at the top and before the import to the pyku
 # individual libaries in order to avoid a circular reference. Hence the flake
@@ -38,86 +37,6 @@ warnings.filterwarnings(
     "You will likely lose important projection information",
     UserWarning,
 )
-
-# Load pyku yaml data
-# -------------------
-
-# The loading of files need be set at the top and before the imports to avoid a
-# circular reference.
-
-drs_file = importlib.resources.files('pyku.etc') / 'drs.yaml'
-
-with open(drs_file) as f:
-    drs_data = yaml.safe_load(f)
-
-area_file = importlib.resources.files('pyku.etc') / 'areas.yaml'
-
-with open(area_file) as f:
-    areas_data = yaml.safe_load(f)
-
-area_cf_file = importlib.resources.files('pyku.etc') / 'areas_cf.yaml'
-
-with open(area_cf_file) as f:
-    areas_cf_data = yaml.safe_load(f)
-
-ensembles_file = \
-    importlib.resources.files('pyku.etc') / 'ensembles.yaml'
-
-with open(ensembles_file) as f:
-    ensembles_data = yaml.safe_load(f)
-
-pyku_metadata_file = \
-    importlib.resources.files('pyku.etc') / 'metadata.yaml'
-
-with open(pyku_metadata_file) as f:
-    meta_dict = yaml.safe_load(f)
-
-pyku_resources_file = \
-    importlib.resources.files('pyku.etc') / 'resources.yaml'
-
-with open(pyku_resources_file) as f:
-    pyku_resources = yaml.safe_load(f)
-
-
-# Set pyku data directories
-# -------------------------
-
-# for the writable data directory (i.e. the one where new data goes), follow
-# the XDG guidelines found at
-# https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-
-# Set default directories
-_writable_dir = Path.home() / '.local' / 'share'
-_data_dir = Path(os.environ.get("XDG_DATA_HOME", _writable_dir)) / 'pyku'
-_cache_dir = Path(tempfile.gettempdir()) / 'pyku_cache_dir'
-
-# Get PYKU_DATA_DIR if it exist
-pre_existing_data_dir = Path(os.environ.get('PYKU_DATA_DIR', ''))
-data_dir = Path(os.environ.get('PYKU_DATA_DIR', str(_data_dir)))
-data_dir_exist = data_dir.exists()
-data_dir_is_directory = data_dir.is_dir()
-data_dir_is_writable = os.access(data_dir, os.W_OK)
-
-# Sanity checks
-if not data_dir_exist:
-    logger.info(f"{data_dir} does not exist")
-if not data_dir_is_directory:
-    logger.info(f"{data_dir} not a directory")
-if not data_dir_is_writable:
-    logger.info(f"{data_dir} not writable")
-
-# Use default data directory if sanity checks failed
-if not data_dir_exist or not data_dir_is_directory or not data_dir_is_writable:
-    data_dir = _data_dir
-
-# Set the pyku configuration
-config = {
-    'pre_existing_data_dir': pre_existing_data_dir,
-    'data_dir': data_dir,
-    'cache_dir': _cache_dir,
-    'repo_data_dir': Path(__file__).parent / 'data',
-    'downloaders': {},
-}
 
 import pyku.magic as magic  # noqa
 import pyku.features as libfeatures  # noqa
@@ -146,8 +65,8 @@ from pyku.timekit import date_range  # noqa
 # -------------------
 
 try:
-    __version__ = importlib.metadata.version(__name__)
-except importlib.metadata.PackageNotFoundError:
+    __version__ = importlib_version(__name__)
+except PackageNotFoundError:
     __version__ = "unknown"
 
 

--- a/pyku/check.py
+++ b/pyku/check.py
@@ -10,9 +10,7 @@ See also:
     * ``./pyku/etc/metadata.yaml``
 """
 
-from . import logger
-from . import drs_data
-from . import meta_dict as meta_data
+from pyku import logger, PYKU_RESOURCES
 
 
 def check(ds, standard=None, completeness_period=None, all_nan_slices=False):
@@ -768,7 +766,7 @@ def check_valid_bounds(ds, bounds=None):
 
             return issues
 
-        bounds_dict = drs_data
+        bounds_dict = PYKU_RESOURCES.get_value('drs')
         ds_varnames = meta.get_geodata_varnames(ds_copy)
 
     data = []
@@ -1440,7 +1438,7 @@ def check_cmor_varnames(ds):
     import pyku.meta as meta
 
     data = [
-        (var, var, None) if var in drs_data.get('variables').keys()
+        (var, var, None) if var in PYKU_RESOURCES.get_keys('drs', 'variables')
         else ('variable name', var, 'Variable not CMOR-conform')
         for var in meta.get_geodata_varnames(ds)
     ]
@@ -1499,9 +1497,13 @@ could not check if standard_name is CMOR-conform"
             the_issue = "Variable has no attribute standard_name"
 
         else:
-            expected_std_name = drs_data.get('variables')\
-                                        .get(cmor_varname)\
-                                        .get('standard_name')
+            expected_std_name = PYKU_RESOURCES.get_value(
+                'drs',
+                'variables',
+                cmor_varname,
+                'standard_name'
+            )
+
             read_std_name = ds[varname].attrs.get('standard_name')
 
             the_result = \
@@ -1569,9 +1571,12 @@ def _check_variables_cmor_long_name(ds):
             the_issue = "Variable has no attribute long_name"
 
         else:
-            expected_long_name = drs_data.get('variables')\
-                                         .get(cmor_varname)\
-                                         .get('long_name')
+            expected_long_name = PYKU_RESOURCES.get_value(
+                'drs',
+                'variables',
+                cmor_varname,
+                'standard_name'
+            )
             read_long_name = ds[varname].attrs.get('long_name')
 
             the_result = \
@@ -1639,8 +1644,13 @@ def _check_variables_cmor_units(ds):
             the_issue = "Variable has no attribute units"
 
         else:
-            expected_units = drs_data.get('variables').get(cmor_varname)\
-                                     .get('cmor_units')
+            expected_units = PYKU_RESOURCES.get_value(
+                'drs',
+                'variables',
+                cmor_varname,
+                'cmor_units'
+            )
+
             read_units = ds[varname].attrs.get('units')
 
             the_result = \
@@ -1808,6 +1818,8 @@ def check_variables_role(ds):
     import pandas as pd
     import pyku.meta as meta
 
+    meta_data = PYKU_RESOURCES.load_resource('metadata')
+
     for var in ds.data_vars:
 
         # Check if crs information depends on time
@@ -1898,24 +1910,23 @@ def check_drs(ds, standard=None):
     # Get available standards from file
     # ---------------------------------
 
-    available_standards = list(drs_data.get('standards').keys())
+    available_standards = list(PYKU_RESOURCES.get_keys('drs', 'standards'))
 
     # Check the standard given as input of the function
     # -------------------------------------------------
 
     if standard not in available_standards:
 
-        message = (
+        raise Exception(
             f"DRS standard {standard} is not implemented. Available standards "
             f"are {available_standards} "
-        )
 
-        raise Exception(message)
+        )
 
     # Get all drs keys from the standard chosen
     # -----------------------------------------
 
-    keys = drs_data.get('standards').get(standard).get('metadata')
+    keys = PYKU_RESOURCES.get_value('drs', 'standards', standard, 'metadata')
 
     # Loop and check
     # --------------
@@ -1960,7 +1971,7 @@ def check_files_multi(
     import pandas as pd
     from dask import delayed
 
-    logger.warn('This function is deprecated')
+    logger.warning('This function is deprecated')
 
     @delayed
     def check_one_file(file):
@@ -2213,7 +2224,7 @@ def compare_datetimes(ds1, ds2):
     if not isinstance(ds1_datetimes[0], np.datetime64) or \
        not isinstance(ds2_datetimes[0], np.datetime64):
 
-        warnings.warn("Only np.datetime64 is fully supported.")
+        warnings.warning("Only np.datetime64 is fully supported.")
 
         issues = pd.DataFrame(
             data=list_of_issues,

--- a/pyku/clix/cli.py
+++ b/pyku/clix/cli.py
@@ -15,7 +15,7 @@ from rapidfuzz import process
 from xclim.core import Quantified  # register new type
 from xclim.core.units import units
 
-from . import indicator_data
+from pyku.clix import indicator_data
 from pyku.clix.manager import (
     get_indicator_description,
     load_function,

--- a/pyku/clix/core.py
+++ b/pyku/clix/core.py
@@ -17,7 +17,7 @@ from dask.distributed import Client, LocalCluster
 from rapidfuzz import process
 from xclim.core.calendar import percentile_doy
 
-from .. import logger
+from pyku import logger
 import pyku.drs as drs
 from pyku.meta import (
     get_geodata_varnames,
@@ -36,7 +36,7 @@ from pyku.clix.custom_indicators import (
     expand_percentiles_to_daily,
     percentile_grouped
 )
-from . import indicator_data
+from pyku.clix import indicator_data
 
 
 # This is necessary to avoid warning using open_mfdataset

--- a/pyku/clix/manager.py
+++ b/pyku/clix/manager.py
@@ -15,8 +15,8 @@ import xarray as xr
 import xclim
 from xclim.core.units import check_units
 
-from .. import logger
-from . import indicator_data
+from pyku import logger
+from pyku.clix import indicator_data
 
 
 @dataclass

--- a/pyku/colormaps.py
+++ b/pyku/colormaps.py
@@ -7,21 +7,11 @@ Reference implementation of DWD color maps
 # Load metadata at module initialization
 # --------------------------------------
 
-import importlib
-import yaml
-from . import logger
+from pyku import logger, PYKU_RESOURCES
+
 
 # Load metadata at module initialization
 # --------------------------------------
-
-base_colours_file = importlib.resources.files(
-    'pyku.etc') / 'base_colours.yaml'
-
-
-with open(base_colours_file) as f:
-    base_colours = yaml.safe_load(f)
-
-
 def get_colormaps_names():
 
     """
@@ -39,7 +29,7 @@ def get_colormaps_names():
               ...: colormaps.get_colormaps_names()
     """
 
-    return list(base_colours.keys())
+    return list(PYKU_RESOURCES.get_keys('base_colours'))
 
 
 def get_cmap_colors(name, kind='original', nbins=None, encoding='hex'):
@@ -125,7 +115,7 @@ def get_cmap(name, kind='original', nbins=None):
 
     if nbins is not None and kind in ['linear', 'original']:
         message = f"Option nbins is ignored when used with kind='{kind}'"
-        logger.warn(message)
+        logger.warning(message)
 
     if nbins is None and kind in ['segmented']:
         message = f"Option nbins shall passed when using kin='{kind}'"
@@ -180,7 +170,7 @@ def get_cmap(name, kind='original', nbins=None):
     # Get colors defined in configuration both as hex and convert to RGB
     # ------------------------------------------------------------------
 
-    hex_colors = base_colours.get(name).get('colours_hex')
+    hex_colors = PYKU_RESOURCES.get_value('base_colours', name, 'colours_hex')
     rgb_colors = [mcolors.hex2color(color) for color in hex_colors]
 
     # Get linear colormap
@@ -285,7 +275,7 @@ kind {kind} not implemented. kind should be one of 'original', 'linear', or \
 
     if nbins is not None and kind in ['linear', 'original']:
         message = f"Option nbins is ignored when used with type={type}"
-        logger.warn(message)
+        logger.warning(message)
 
     if nbins is None and kind in ['segmented']:
         message = f"Option nbins shall passed when using type={type}"

--- a/pyku/compute.py
+++ b/pyku/compute.py
@@ -4,7 +4,7 @@
 Processing library
 """
 
-from . import logger
+from pyku import logger
 
 
 def inpainting(ds_in, roi=3, method="INPAINT_TELEA"):
@@ -414,7 +414,7 @@ def calc_tdew(ds):
     if tas_cm and hurs_cm and (tas_cm == hurs_cm):
         tdew.attrs['cell_methods'] = tas_cm
     else:
-        logger.warn(
+        logger.warning(
             "cell_methods not set: attributes either differ or are missing "
             "from input data"
         )
@@ -527,7 +527,7 @@ def calc_hurs(ds):
     if ps_cm and tas_cm and huss_cm and (ps_cm == tas_cm == huss_cm):
         hurs.attrs['cell_methods'] = ps_cm
     else:
-        logger.warn(
+        logger.warning(
             "cell_methods not set: attributes either differ or are missing "
             "from input data"
         )
@@ -616,7 +616,7 @@ def calc_huss(ds):
     if ps_cm and tdew_cm and (ps_cm == tdew_cm):
         huss.attrs['cell_methods'] = ps_cm
     else:
-        logger.warn(
+        logger.warning(
             "cell_methods not set: attributes either differ or are missing "
             "from input data"
         )
@@ -911,8 +911,8 @@ GWL_temp_offset must be a float, got {GWL_temp_offset}!
 
     if ds.attrs['frequency'] == 'day':
         fac = 365
-        logger.warn("Detected data frequency is 'day', " +
-                    "assuming a 365-day calendar on the underlying data.")
+        logger.warning("Detected data frequency is 'day', " +
+                       "assuming a 365-day calendar on the underlying data.")
 
     # Calculate temperature anomalies
     # -------------------------------
@@ -1266,7 +1266,7 @@ def persistent_processing(
             # ------------------------
 
             if 'time' not in processed_data.dims:
-                logger.warn(
+                logger.warning(
                     "The 'time' dimension is missing. This function is "
                     "specifically designed for datasets with a temporal "
                     "component."

--- a/pyku/core/__init__.py
+++ b/pyku/core/__init__.py
@@ -1,0 +1,4 @@
+from pyku.core.resource_provider import PykuResourceProviderSingleton \
+    as PYKU_RESOURCES  # noqa: F401
+from pyku.core.config_provider import PykuConfigProviderSingleton \
+    as PYKU_CONFIG  # noqa: F401

--- a/pyku/core/config_provider.py
+++ b/pyku/core/config_provider.py
@@ -1,0 +1,86 @@
+import os
+import tempfile
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# for the writable data directory (i.e. the one where new data goes), follow
+# the XDG guidelines found at
+# https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+
+class PykuConfigProvider:
+    """Provides configuration settings for the pyku package."""
+
+    def __init__(self):
+        # Set default directories
+        _writable_dir = Path.home() / '.local' / 'share'
+        _data_dir = Path(os.environ.get("XDG_DATA_HOME", _writable_dir)) / \
+            'pyku'
+        _cache_dir = Path(tempfile.gettempdir()) / 'pyku_cache_dir'
+
+        # Get PYKU_DATA_DIR if it exist
+        pre_existing_data_dir = Path(os.environ.get('PYKU_DATA_DIR', ''))
+        data_dir = Path(os.environ.get('PYKU_DATA_DIR', str(_data_dir)))
+
+        # Sanity checks
+        if not _check_sanity(data_dir):
+            data_dir = _data_dir
+
+        # Set the pyku configuration
+        self.config = {
+            'pre_existing_data_dir': pre_existing_data_dir,
+            'data_dir': data_dir,
+            'cache_dir': _cache_dir,
+            'repo_data_dir': Path(__file__).parent / 'data',
+            'default_data_dir': _data_dir,
+            'downloaders': {},
+        }
+        logger.debug("Using pyku data directory: %s", self.config['data_dir'])
+
+    def get(self, key):
+        """Retrieve a configuration value by key."""
+        return self.config.get(key)
+
+    def set(self, key, value):
+        """Set a configuration value by key."""
+        self.config[key] = value
+
+    @property
+    def data_dir(self):
+        """Get the data directory."""
+        return self.get('data_dir')
+
+    @data_dir.setter
+    def data_dir(self, path):
+        """Set the data directory."""
+        self.set('data_dir', Path(path))
+
+    @property
+    def cache_dir(self):
+        """Get the cache directory."""
+        return self.get('cache_dir')
+
+    @cache_dir.setter
+    def cache_dir(self, path):
+        """Set the cache directory."""
+        self.set('cache_dir', Path(path))
+
+
+def _check_sanity(data_dir: Path) -> bool:
+    """Check if the data directory is valid."""
+    if not data_dir.exists():
+        logger.info("%s does not exist", data_dir)
+        return False
+    if not data_dir.is_dir():
+        logger.info("%s not a directory", data_dir)
+        return False
+    if not os.access(data_dir, os.W_OK):
+        logger.info("%s not writable", data_dir)
+        return False
+    return True
+
+
+PykuConfigProviderSingleton = PykuConfigProvider()

--- a/pyku/core/resource_provider.py
+++ b/pyku/core/resource_provider.py
@@ -1,0 +1,125 @@
+"""
+Resource Manager
+"""
+
+import yaml
+
+
+class PykuResourceProvider:
+    """Following the singleton design pattern, this class is meant
+    to provide an global instance of a resource manager. An instance is
+    created during initialization of pyku, and provides access to all (yaml)
+    files in etc/ on a per-read basis (while enabling caching)"""
+    def __init__(self, resource_dir='pyku.etc'):
+        """ Initialise a resource manager with a given package internal
+        directory/module
+        """
+        import importlib.resources
+
+        self._resource_dir = importlib.resources.files(resource_dir)
+        self.clear_cache()
+
+    def load_resource(self, resource_name: str):
+        """ On the fly resource loading and caching """
+        if resource_name in self._resource_cache:
+            return self._resource_cache[resource_name]
+
+        resource_path = self._resource_dir / (resource_name + '.yaml')
+
+        if not resource_path.exists():
+            raise FileNotFoundError(f"Resource file not found: \
+                                    {resource_path}")
+
+        resource = _parse_yaml_file(resource_path)
+
+        self._resource_cache[resource_name] = resource
+
+        return resource
+
+    def clear_cache(self):
+        self._resource_cache = {}
+
+    def get_value(self, resource_name, *keys, **kwargs):
+        """ get a specific key from a resource file giving
+        ordered arguments indicating the dictionary chain
+
+        Params:
+            resource_name (str) : a file in etc/ given without extension
+                                    i.e. 'areas_cf'
+            *args (str)         : arbitrary number of ordered strings that
+                                    get refere to keys within the opened
+                                    resource file.
+            **kwargs            : only 'default' as a kwargs gets used. If
+                                    given, this value gets returned. Only
+                                    works with at least one given *arg
+
+        Returns:
+            Union[Dict,int, float, str]
+
+        Example:
+            resource_provider = PykuResourceProvider()
+            drs_standards = resource_provider.get_keys('drs','standards')
+            # returns e.g. {'cmip5':{...},'cmip6':{...},....}
+        """
+        d = self.load_resource(resource_name)
+        return _walk_dictionary(d, *keys, **kwargs)
+
+    def get_keys(self, resource_name, *keys):
+        """ get all keys of a resource at the level *keys
+
+        resource_name (str) : a file in etc/ given without extension
+                                i.e. 'areas_cf'
+        *args (str)         : arbitrary number of ordered strings that
+                                referes to key-chains within the opened
+                                resource file.
+
+        Returns:
+            DictKeys
+
+        Example:
+            resource_provider = PykuResourceProvider()
+            drs_standards = resource_provider.get_keys('drs','standards')
+            # returns e.g. DictKeys['cmip5','cmip6',....]
+        """
+        return self.get_value(resource_name, *keys).keys()
+
+
+PykuResourceProviderSingleton = PykuResourceProvider()
+
+
+# Private Helper Functions
+def _parse_yaml_file(resource_path):
+    """ Helper function to safe_load a yaml file """
+    with open(resource_path, encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return data
+
+
+def _walk_dictionary(d, *keys, **kwargs):
+    """helper function to walk through a dictionary
+    in an ordered way through *keys and returns the
+    resulting value
+
+    Params:
+        d (dict) : Dictionary to walk through
+        *keys (str) : ordered strings of keys
+                    inside of d
+        **kwargs (str) : only `default` has an effect.
+                    if key-chain *keys is not found in
+                    d, default gets returned. otherwise
+                    a KeyError
+
+    Returns:
+        Union[dict, int, float, str]
+
+    Raises:
+        KeyError : when *args not in d
+    """
+    for key in keys:
+        if isinstance(d, dict) and key in d:
+            d = d[key]
+        else:
+            if 'default' in kwargs.keys():
+                return kwargs.get('default', None)
+            raise KeyError(f"Key {key} not found")
+    return d

--- a/pyku/downscale.py
+++ b/pyku/downscale.py
@@ -4,7 +4,7 @@
 Downscaling library
 """
 
-from . import logger
+from pyku import logger
 
 
 class Downscaler:

--- a/pyku/drs.py
+++ b/pyku/drs.py
@@ -28,8 +28,26 @@ __all__ = [
             ]
 
 import xarray as xr
-from . import drs_data
-from . import logger
+
+from pyku import logger, PYKU_RESOURCES
+
+
+def _check_available_standards(standard):
+    """
+    Checks if a standard is defined in etc/drs.standards
+
+    Returns:
+        None
+
+    Raises:
+        Value Error if standard is not defined
+    """
+    _available_standards = PYKU_RESOURCES.get_keys('drs', 'standards')
+    if standard not in _available_standards:
+        raise ValueError(
+            f"DRS standard {standard} not implemented. Available standards "
+            f"are {_available_standards}"
+        )
 
 
 def list_drs_standards():
@@ -40,7 +58,7 @@ def list_drs_standards():
         List(str): List of DRS standards.
     """
 
-    return list(drs_data['standards'].keys())
+    return list(PYKU_RESOURCES.get_keys('drs', 'standards'))
 
 
 def drs_filename(ds, varname=None, standard=None, version=None):
@@ -99,19 +117,10 @@ def drs_filename(ds, varname=None, standard=None, version=None):
             f"following variables: {ds.data_vars}."
         )
 
-    # Get available standards from file
-    # ---------------------------------
+    # Check available standards
+    # -------------------------
 
-    available_standards = list(drs_data.get('standards').keys())
-
-    # Check the standard given as input of the function
-    # -------------------------------------------------
-
-    if standard not in available_standards:
-        raise ValueError(
-            f"DRS standard {standard} not implemented. Available standards "
-            f"are {available_standards}"
-        )
+    _check_available_standards(standard)
 
     path = drs_parent(
         ds,
@@ -201,19 +210,10 @@ def drs_stem(ds, varname=None, standard=None):
 
     variable_name = variable_names[0]  # noqa
 
-    # Get available standards from file
-    # ---------------------------------
+    # Check available standards
+    # -------------------------
 
-    available_standards = list(drs_data.get('standards').keys())
-
-    # Check the standard given as input of the function
-    # -------------------------------------------------
-
-    if standard not in available_standards:
-        raise ValueError(
-            f"DRS standard {standard} does not exist DRS standards available "
-            f"are: {available_standards}"
-        )
+    _check_available_standards(standard)
 
     # Initialize the filename
     # -----------------------
@@ -278,8 +278,7 @@ def drs_stem(ds, varname=None, standard=None):
     # -------------------------------
 
     filename_pattern = (
-        drs_data.get('standards')
-        .get(standard).get('stem_pattern')
+        PYKU_RESOURCES.get_value('drs', 'standards', standard, 'stem_pattern')
     )
 
     # Get all variables needed from file pattern
@@ -383,19 +382,10 @@ def drs_parent(ds, varname=None, standard=None, version=None):
     if varname is not None:
         raise Exception("Parameter 'varname' is deprecated")
 
-    # Get available standards from file
-    # ---------------------------------
+    # Check available standards
+    # -------------------------
 
-    available_standards = list(drs_data.get('standards').keys())
-
-    # Check the standard given as input of the function
-    # -------------------------------------------------
-
-    if standard not in available_standards:
-        raise KeyError(
-            f"DRS standard {standard} does not exist. "
-            f"Available DRS standards available are: {available_standards}"
-        )
+    _check_available_standards(standard)
 
     # Generate a namespace to store local variables
     # ---------------------------------------------
@@ -427,11 +417,10 @@ def drs_parent(ds, varname=None, standard=None, version=None):
     # Get file pattern from json file
     # -------------------------------
 
-    pathname_pattern = (
-        drs_data.get('standards')
-        .get(standard)
-        .get('parent_pattern')
-    )
+    pathname_pattern = PYKU_RESOURCES.get_value('drs',
+                                                'standards',
+                                                standard,
+                                                'parent_pattern')
 
     # Get all variables needed from file pattern
     # ------------------------------------------
@@ -601,8 +590,8 @@ def to_drs_netcdfs(
         "One and only one CMOR variable in dataset supported"
 
     if 'time' not in list(dict(ds.sizes).keys()):
-        logger.warn("No 'time' dimension found in dataset")
-        logger.warn("Trying cmorization of a constant field")
+        logger.warning("No 'time' dimension found in dataset")
+        logger.warning("Trying cmorization of a constant field")
 
         # No grouping necessary
         groups = [1]
@@ -887,7 +876,10 @@ def _to_precipitations_cmor_units(ds, var=None):
     # Set the CMOR precipitation units
     # --------------------------------
 
-    da.attrs['units'] = drs_data.get('variables').get('pr').get('cmor_units')
+    da.attrs['units'] = PYKU_RESOURCES.get_value('drs',
+                                                 'variables',
+                                                 'pr',
+                                                 'cmor_units')
 
     # Set CMOR attributes
     # -------------------
@@ -897,15 +889,11 @@ def _to_precipitations_cmor_units(ds, var=None):
     # standard_name and long_name, that this is set here.
 
     da.attrs['standard_name'] = (
-        drs_data.get('variables')
-        .get('pr')
-        .get('standard_name')
+        PYKU_RESOURCES.get_value('drs', 'variables', 'pr', 'standard_name')
     )
 
     da.attrs['long_name'] = (
-        drs_data.get('variables')
-        .get('pr')
-        .get('long_name')
+        PYKU_RESOURCES.get_value('drs', 'variables', 'pr', 'long_name')
     )
 
     # Overwrite DataArray into Dataset and return
@@ -968,7 +956,7 @@ def to_cmor_units(ds):
 
         cmor_varname = get_cmor_varname(ds_out[var])
 
-        if cmor_varname in drs_data.get('variables').keys():
+        if cmor_varname in PYKU_RESOURCES.get_keys('drs', 'variables'):
 
             # Deal with units of precipitations, which can be creative
             # --------------------------------------------------------
@@ -983,9 +971,10 @@ def to_cmor_units(ds):
                 # --------------------------
 
                 units = (
-                    drs_data.get('variables')
-                    .get(cmor_varname)
-                    .get('units')
+                    PYKU_RESOURCES.get_value('drs',
+                                             'variables',
+                                             cmor_varname,
+                                             'units')
                 )
 
                 # Quantify
@@ -1007,9 +996,10 @@ def to_cmor_units(ds):
                 # ------------------
 
                 da.attrs['units'] = (
-                    drs_data.get('variables')
-                    .get(cmor_varname)
-                    .get('cmor_units')
+                    PYKU_RESOURCES.get_value('drs',
+                                             'variables',
+                                             cmor_varname,
+                                             'cmor_units')
                 )
 
                 ds_out[var] = da
@@ -1039,28 +1029,31 @@ def get_cmor_varname(da):
     # Case where the name of the variable is already CMOR-conform
     # -----------------------------------------------------------
 
-    if da.name in drs_data.get('variables').keys():
+    if da.name in PYKU_RESOURCES.get_keys('drs', 'variables'):
         return da.name
 
     # Try identifying the variable with `other_names`
     # -----------------------------------------------
 
-    for var in drs_data.get('variables').keys():
-        if da.name in drs_data.get('variables').get(var).get('other_names'):
+    for var in PYKU_RESOURCES.get_keys('drs', 'variables'):
+        if da.name in PYKU_RESOURCES.get_value('drs',
+                                               'variables',
+                                               var,
+                                               'other_names'):
             return var
 
     # Try identifying the variable with `standard_name`
     # -------------------------------------------------
 
-    for var in drs_data.get('variables').keys():
+    for var in PYKU_RESOURCES.get_keys('drs', 'variables'):
 
         if (
             da.attrs.get('standard_name') is not None and
             da.attrs.get('standard_name') in (
-                drs_data
-                .get('variables')
-                .get(var)
-                .get('standard_name')
+                PYKU_RESOURCES.get_value('drs',
+                                         'variables',
+                                         var,
+                                         'standard_name')
                 )
         ):
 
@@ -1069,15 +1062,14 @@ def get_cmor_varname(da):
     # Try identifying the variable with `long_name`
     # ---------------------------------------------
 
-    for var in drs_data.get('variables').keys():
-
+    for var in PYKU_RESOURCES.get_keys('drs', 'variables'):
         if (
             da.attrs.get('long_name') is not None and
             da.attrs.get('long_name') in (
-                drs_data
-                .get('variables')
-                .get(var)
-                .get('long_name')
+                PYKU_RESOURCES.get_value('drs',
+                                         'variables',
+                                         var,
+                                         'long_name')
             )
         ):
 
@@ -1194,7 +1186,7 @@ def _to_cmor_attrs_var(ds):
 
         cmor_varname = get_cmor_varname(ds[var])
 
-        if cmor_varname in drs_data.get('variables').keys():
+        if cmor_varname in PYKU_RESOURCES.get_keys('drs', 'variables'):
 
             # Send a warning if rotated wind components are found
             # ---------------------------------------------------
@@ -1217,17 +1209,17 @@ def _to_cmor_attrs_var(ds):
             # -------------------
 
             ds[var].attrs['standard_name'] = (
-                drs_data
-                .get('variables')
-                .get(cmor_varname)
-                .get('standard_name')
+                PYKU_RESOURCES.get_value('drs',
+                                         'variables',
+                                         cmor_varname,
+                                         'standard_name')
             )
 
             ds[var].attrs['long_name'] = (
-                drs_data
-                .get('variables')
-                .get(cmor_varname)
-                .get('long_name')
+                PYKU_RESOURCES.get_value('drs',
+                                         'variables',
+                                         cmor_varname,
+                                         'long_name')
             )
 
         else:
@@ -1255,14 +1247,17 @@ def _get_cmor_coordinate_name(coordinate_name):
     # Case where the name of the coordinate is already CMOR-conform
     # -------------------------------------------------------------
 
-    if coordinate_name in drs_data.get('coordinates').keys():
+    if coordinate_name in PYKU_RESOURCES.get_keys('drs', 'coordinates'):
         return coordinate_name
 
     # Try identifying the variable with aliases
     # -----------------------------------------
 
-    for name in drs_data.get('coordinates').keys():
-        if name in drs_data.get('coordinates').get(name).get('aliases'):
+    for name in PYKU_RESOURCES.get_keys('drs', 'coordinates'):
+        if name in PYKU_RESOURCES.get_value('drs',
+                                            'coordinates',
+                                            name,
+                                            'aliases'):
             return name
 
     # We have reached the end and could not find the variable
@@ -1298,7 +1293,10 @@ def _to_cmor_attrs_coords(ds):
         if _get_cmor_coordinate_name(coordinate) is not None:
 
             ds[coordinate].attrs = \
-                drs_data.get('coordinates').get(coordinate).get('attrs')
+                PYKU_RESOURCES.get_value('drs',
+                                         'coordinates',
+                                         coordinate,
+                                         'attrs')
 
         else:
             message = \
@@ -1470,7 +1468,7 @@ def get_facets_from_file_parent(filename, standard, has_version=False):
     Note:
 
         The available standards are available in dictionary
-        ``pyku.drs.drs_data``:
+        ``pyku.PYKU_RESOURCES.load_resource('drs')``:
 
         .. ipython::
 
@@ -1481,9 +1479,10 @@ def get_facets_from_file_parent(filename, standard, has_version=False):
 
         .. ipython::
 
-           In [0]: print(drs.drs_data.get('standards')\\
-              ...:                   .get('cordex')\\
-              ...:                   .get('parent_pattern'))
+           In [0]: print(pyku.PYKU_RESOURCES.get_value('drs', \
+                                                       'standards', \
+                                                       'cordex', \
+                                                       'parent_pattern'))
 
     Example:
 
@@ -1512,10 +1511,10 @@ def get_facets_from_file_parent(filename, standard, has_version=False):
     # ------------------------------
 
     parent_pattern = (
-        drs_data
-        .get('standards')
-        .get(standard)
-        .get('parent_pattern')
+        PYKU_RESOURCES.get_value('drs',
+                                 'standards',
+                                 standard,
+                                 'parent_pattern')
     )
 
     # Deal with the variable name
@@ -1590,20 +1589,21 @@ def get_facets_from_file_stem(filename, standard):
     Note:
 
         The available standards are available in dictionary
-        ``pyku.drs.drs_data``:
+        ``pyku.PYKU_RESOURCES.load_resource('drs')``:
 
         .. ipython::
 
            In [0]: import pyku.drs as drs
-              ...: list(drs.drs_data.get('standards').keys())
+              ...: list(drs.PYKU_RESOURCES.get_keys('drs', 'standards'))
 
         For example the patterns for the cordex standard can be obtained with:
 
         .. ipython::
 
-           In [0]: print(drs.drs_data.get('standards')\\
-              ...:                   .get('cordex')\\
-              ...:                   .get('stem_pattern'))
+           In [0]: print(pyku.PYKU_RESOURCES.get_value('drs', \
+                                                       'standards', \
+                                                       'cordex', \
+                                                       'stem_pattern'))
 
     Example:
 
@@ -1628,10 +1628,7 @@ def get_facets_from_file_stem(filename, standard):
     # ------------------------------
 
     stem_pattern = (
-        drs_data
-        .get('standards')
-        .get(standard)
-        .get('stem_pattern')
+        PYKU_RESOURCES.get_value('drs', 'standards', standard, 'stem_pattern')
     )
 
     # Get stem from file name

--- a/pyku/features.py
+++ b/pyku/features.py
@@ -4,7 +4,7 @@
 Functions for dealing with features (polygons, points).
 """
 
-from . import logger
+from pyku import logger
 
 
 def rasterize_points(features, area_def, reference_datetime=None):
@@ -34,7 +34,7 @@ def rasterize_points(features, area_def, reference_datetime=None):
     import rasterio
     import rasterio.features
 
-    logger.warn("This function is not maintained.")
+    logger.warning("This function is not maintained.")
 
     # Get coordinates from area definition
     # ------------------------------------

--- a/pyku/find.py
+++ b/pyku/find.py
@@ -13,9 +13,7 @@ __all__ = [
 Functions for finding data
 """
 
-from . import logger
-from . import drs_data
-from . import ensembles_data
+from pyku import logger, PYKU_RESOURCES
 
 
 def expand_unix_patterns(patterns, regex=None):
@@ -234,7 +232,8 @@ def get_files_by_drs(standard, parent_dir=None,
     # Raise exception if the standard is not defined
     # ----------------------------------------------
 
-    if standard not in list(drs_data.get('standards').keys()):
+    if standard not in list(PYKU_RESOURCES.get_value('drs',
+                                                     'standards').keys()):
         message = f"standard {standard} not defined"
         raise Exception(message)
 
@@ -242,9 +241,10 @@ def get_files_by_drs(standard, parent_dir=None,
     # -------------------------------------------------
 
     parent_pattern = \
-        drs_data.get('standards').get(standard).get('parent_pattern')
+        PYKU_RESOURCES.get_value('drs', 'standards', standard,
+                                 'parent_pattern')
     stem_pattern = \
-        drs_data.get('standards').get(standard).get('stem_pattern')
+        PYKU_RESOURCES.get_value('drs', 'standards', standard, 'stem_pattern')
 
     # Raise exception if parent_dir does not exist
     # --------------------------------------------
@@ -592,7 +592,7 @@ def select_files_by_datetimes(
             ]
 
             if is_weird_calendar:
-                logger.warn("cftime implementation needs testing")
+                logger.warning("cftime implementation needs testing")
 
         # Convert to pandas Timestamp
         # ---------------------------
@@ -1106,7 +1106,7 @@ def get_file_dataframe(files, standard='cordex'):
     # Raise exception if the standard is not defined
     # ----------------------------------------------
 
-    if standard not in list(drs_data.get('standards').keys()):
+    if standard not in list(PYKU_RESOURCES.get_keys('drs', 'standards')):
         message = f"standard {standard} not defined"
         raise Exception(message)
 
@@ -1130,7 +1130,10 @@ def get_file_dataframe(files, standard='cordex'):
     # Get the current standard
     # ------------------------
 
-    stem_pattern = drs_data.get('standards').get(standard).get('stem_pattern')
+    stem_pattern = PYKU_RESOURCES.get_value('drs',
+                                            'standards',
+                                            standard,
+                                            'stem_pattern')
 
     # Filter files that do not match the pattern
     # ------------------------------------------
@@ -1149,7 +1152,7 @@ def get_file_dataframe(files, standard='cordex'):
             filtered_files.append(file)
         else:
             message = f"Cannot read pattern from {file}. Skipping."
-            logger.warn(message)
+            logger.warning(message)
 
     files = filtered_files
 
@@ -1238,7 +1241,7 @@ def get_ensemble_definition(ensemble):
     # Get data from yaml file
     # -----------------------
 
-    data = ensembles_data.get(ensemble)
+    data = PYKU_RESOURCES.load_resource('ensembles').get(ensemble)
 
     # Construct dataframe
     # -------------------
@@ -1349,4 +1352,4 @@ def list_ensembles():
               ...: pyku.list_ensembles()
     """
 
-    return list(ensembles_data.keys())
+    return list(PYKU_RESOURCES.get_keys('ensembles'))

--- a/pyku/geo.py
+++ b/pyku/geo.py
@@ -14,9 +14,8 @@ https://cordex.org/domains/
 
 """
 
-from . import logger
-from . import areas_cf_data
-from . import areas_data
+from pyku import PYKU_RESOURCES, logger
+
 
 # Define projections which are deprecated. This should be removed in a later
 # version of pyku
@@ -45,7 +44,7 @@ def list_standard_areas():
         List[str]: List of pyku standard areas
     """
 
-    return list(areas_data.keys())
+    return list(PYKU_RESOURCES.get_keys('areas'))
 
 
 def get_areas_cf_definitions():
@@ -64,7 +63,7 @@ def get_areas_cf_definitions():
 
     """
 
-    return areas_cf_data
+    return PYKU_RESOURCES.load_resource('areas_cf')
 
 
 def get_areas_definitions():
@@ -82,7 +81,7 @@ def get_areas_definitions():
               ...: geo.get_areas_definitions().keys()
     """
 
-    return areas_data
+    return PYKU_RESOURCES.load_resource('areas')
 
 
 def load_area_def(projection_name, area_file=None):
@@ -1988,7 +1987,7 @@ def select_area_extent(
     elif x_ordering == 'descending':
         ds_copy = ds_copy.sel({x_varname: slice(upper_right_x, lower_left_x)})
     else:
-        logger.warn(
+        logger.warning(
             f'Reordering projection coordinate {x_varname} in ascending order'
         )
         ds_copy = ds_copy.sortby(x_varname, ascending=True)
@@ -1999,7 +1998,7 @@ def select_area_extent(
     elif y_ordering == 'descending':
         ds_copy = ds_copy.sel({y_varname: slice(upper_right_y, lower_left_y)})
     else:
-        logger.warn(
+        logger.warning(
             f'Reordering projection coordinate {y_varname} in ascending order'
         )
         ds_copy = ds_copy.sortby(y_varname, ascending=True)
@@ -3361,13 +3360,13 @@ def project(
         # reading the CF-conform area definition.
 
         out_da.coords['lat'].attrs = \
-            drs.drs_data.get('coordinates').get('lat')['attrs']
+            PYKU_RESOURCES.get_value('drs', 'coordinates', 'lat')['attrs']
         out_da.coords['lon'].attrs = \
-            drs.drs_data.get('coordinates').get('lon')['attrs']
+            PYKU_RESOURCES.get_value('drs', 'coordinates', 'lon')['attrs']
         out_da.coords['y'].attrs = \
-            drs.drs_data.get('coordinates').get('y')['attrs']
+            PYKU_RESOURCES.get_value('drs', 'coordinates', 'y')['attrs']
         out_da.coords['x'].attrs = \
-            drs.drs_data.get('coordinates').get('x')['attrs']
+            PYKU_RESOURCES.get_value('drs', 'coordinates', 'x')['attrs']
 
         # Append DataArray to the list of DataArrays
         # ------------------------------------------

--- a/pyku/magic.py
+++ b/pyku/magic.py
@@ -7,7 +7,7 @@ This modules redefines default parameters to fit the most common use when
 working with climate data.
 """
 
-from . import logger
+from pyku import logger
 
 
 def sorcery(ds):
@@ -56,7 +56,7 @@ def open_mfdataset(files, option='auto'):
 
     import xarray as xr
 
-    logger.warn("Experimental")
+    logger.warning("Experimental")
 
     if option not in ['auto']:
         raise Exception("Only option='auto' is implemented")

--- a/pyku/meta.py
+++ b/pyku/meta.py
@@ -60,8 +60,7 @@ For more detailed information on each function, refer to their respective
 docstrings.
 """
 
-from . import meta_dict
-from . import logger
+from pyku import logger, PYKU_RESOURCES
 
 
 def find_match(searched_words, words, excluded_words=None):
@@ -146,7 +145,7 @@ def find_match(searched_words, words, excluded_words=None):
             f"Found {exact_words}. Using {exact_words[0]} "
         )
 
-        logger.warn(message)
+        logger.warning(message)
 
         return exact_words[0]
 
@@ -245,7 +244,7 @@ def get_pyku_metadata():
         dict: dictionary of pyku metadata
     """
 
-    return meta_dict
+    return PYKU_RESOURCES.get_value('metadata')
 
 
 def get_dataset_size(ds):
@@ -490,7 +489,8 @@ def get_spatial_vertices_varnames(ds):
     # --------------------------------------------
 
     spatial_vertices_varnames = list(
-        set(meta_dict.get("spatial_vertices")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata', 'spatial_vertices')) &
+        set(ds.data_vars)
     )
 
     return spatial_vertices_varnames
@@ -519,7 +519,8 @@ def get_spatial_bounds_varnames(ds):
     # --------------------------------------------
 
     spatial_bnds_varnames = list(
-        set(meta_dict.get("spatial_bounds")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata', 'spatial_bounds')) &
+        set(ds.data_vars)
     )
 
     return spatial_bnds_varnames
@@ -545,11 +546,13 @@ def get_latlon_bounds_varnames(ds):
     """
 
     possible_lat_bounds_varnames = list(
-        set(meta_dict.get("latitude_bounds")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata', 'latitude_bounds')) &
+        set(ds.data_vars)
     )
 
     possible_lon_bounds_varnames = list(
-        set(meta_dict.get("longitude_bounds")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata', 'longitude_bounds')) &
+        set(ds.data_vars)
     )
 
     if len(possible_lat_bounds_varnames) == 0:
@@ -656,7 +659,10 @@ def get_crs_varname(ds):
     # --------------------------------------------
 
     crs_varnames = list(
-        set(meta_dict.get("coordinate_reference_system")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata',
+                                     'coordinate_reference_system')
+            ) &
+        set(ds.data_vars)
     )
 
     if len(crs_varnames) > 1:
@@ -719,7 +725,8 @@ def get_time_bounds_varname(ds):
     # --------------------------------------------
 
     time_bnds_varnames = list(
-        set(meta_dict.get("temporal_bounds")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata', 'temporal_bounds')) &
+        set(ds.data_vars)
     )
 
     # Raise a warning if multiple values are found
@@ -789,7 +796,8 @@ def get_time_bounds(ds, which=None):
     # --------------------------------------------
 
     time_bnds_names = list(
-        set(meta_dict.get("temporal_bounds")) & set(ds.data_vars)
+        set(PYKU_RESOURCES.get_value('metadata', 'temporal_bounds')) &
+        set(ds.data_vars)
     )
 
     if len(time_bnds_names) > 1:
@@ -1450,12 +1458,13 @@ def get_geographic_latlon_varnames(ds):
     # ---------------------------------------------
 
     # Get valid names
-    valid_lat_names = meta_dict["geographic_latitude"]
+    valid_lat_names = PYKU_RESOURCES.get_value('metadata',
+                                               'geographic_latitude')
 
     # Get other coordinate names, flatten the list of list to a list
     other_coord_names = [
         value
-        for key, value in meta_dict.items()
+        for key, value in PYKU_RESOURCES.load_resource('metadata').items()
         if key != "geographic_latitude"
     ]
 
@@ -1472,12 +1481,13 @@ def get_geographic_latlon_varnames(ds):
     # ---------------------------------------------
 
     # Get valid names
-    valid_lon_names = meta_dict["geographic_longitude"]
+    valid_lon_names = PYKU_RESOURCES.get_value('metadata',
+                                               'geographic_longitude')
 
     # Get other coordinate names, flattten the list of list ot a list
     other_coord_names = [
         value
-        for key, value in meta_dict.items()
+        for key, value in PYKU_RESOURCES.load_resource('metadata').items()
         if key != "geographic_longitude"
     ]
 
@@ -1533,12 +1543,13 @@ def get_projection_yx_varnames(ds):
     # ---------------------------------------------
 
     # Get valid names
-    valid_y_names = meta_dict["projection_coordinate_y"]
+    valid_y_names = PYKU_RESOURCES.get_value('metadata',
+                                             'projection_coordinate_y')
 
     # Get other coordinate names, flatten the list of list to a list
     other_coord_names = [
         value
-        for key, value in meta_dict.items()
+        for key, value in PYKU_RESOURCES.load_resource('metadata').items()
         if key != "projection_coordinate_y"
     ]
 
@@ -1553,12 +1564,13 @@ def get_projection_yx_varnames(ds):
     # ---------------------------------------------
 
     # Get valid names
-    valid_x_names = meta_dict["projection_coordinate_x"]
+    valid_x_names = PYKU_RESOURCES.get_value('metadata',
+                                             'projection_coordinate_x')
 
     # Get other coordinate names, flattten the list of list ot a list
     other_coord_names = [
         value
-        for key, value in meta_dict.items()
+        for key, value in PYKU_RESOURCES.load_resource('metadata').items()
         if key != "projection_coordinate_x"
     ]
 
@@ -1623,8 +1635,10 @@ def get_geodata_varnames(ds):
                 has_geographic_coordinates(ds[var]) or
                 has_projection_coordinates(ds[var])
             ) and
-            var not in meta_dict.get("spatial_vertices") and
-            var not in meta_dict.get("spatial_bounds")
+            var not in PYKU_RESOURCES.get_value('metadata',
+                                                'spatial_vertices') and
+            var not in PYKU_RESOURCES.get_value('metadata',
+                                                'spatial_bounds')
         )
     ]
 

--- a/pyku/pdftransfer.py
+++ b/pyku/pdftransfer.py
@@ -22,7 +22,7 @@ have dimensions (nfeatures x ntimes x nlats x nlons):
 
 """
 
-from . import logger
+from pyku import logger
 
 # Set precision
 # -------------
@@ -1078,7 +1078,7 @@ class PDFCorrector:
 
         if block_size is not None:
 
-            logger.warn(
+            logger.warning(
                 "block_size is deprecated, use parameter chunks while "
                 "opening with open_mfdataset"
             )

--- a/pyku/pyku.py
+++ b/pyku/pyku.py
@@ -6,7 +6,7 @@ pyku command line utilities
 
 import argparse
 
-from . import __version__
+from pyku import __version__
 
 
 def read_parameters():

--- a/pyku/resources.py
+++ b/pyku/resources.py
@@ -8,9 +8,13 @@ __all__ = [
     'list_polygon_identifiers'
 ]
 
-from . import config as pyku_config
-from . import pyku_resources
-from . import logger
+import warnings
+from zarr.errors import ZarrUserWarning
+
+from pyku import logger
+from pyku import PYKU_RESOURCES, PYKU_CONFIG
+
+pyku_resources = PYKU_RESOURCES.load_resource('resources')
 
 # Supress warnings
 # ----------------
@@ -26,9 +30,6 @@ from . import logger
 # by other Zarr libraries. Use this data type at your own risk! Check
 # https://github.com/zarr-developers/zarr-extensions/tree/main/data-types for
 # the status of data type specifications for Zarr V3.
-
-import warnings
-from zarr.errors import ZarrUserWarning
 
 warnings.filterwarnings(
     "ignore",
@@ -51,7 +52,7 @@ def _warn_if_default_data_dir():
     from . import _data_dir
 
     default_data_dir = Path(_data_dir).resolve()
-    current_path = pyku_config.get('data_dir')
+    current_path = Path(PYKU_CONFIG.get('data_dir'))
     current_data_dir = Path(current_path).resolve()
 
     if default_data_dir == current_data_dir:
@@ -72,7 +73,7 @@ def _warn_of_data_download(pooch_installer):
 
     from pathlib import Path
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     filenames = ", ".join(pooch_installer.registry.keys())
 
@@ -103,7 +104,7 @@ def _pooch_download(base_url=None, archive_file=None, target_file=None,
     # Get the pyku data directory
     # --------------------------
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     # Create pooch installer
     # ----------------------
@@ -213,7 +214,7 @@ def list_polygon_identifiers():
               ...: pyku.list_polygon_identifiers()
     """
 
-    return list(pyku_resources.get('polygons').keys())
+    return list(PYKU_RESOURCES.get_keys('resources', 'polygons'))
 
 
 def get_polygon_identifiers():
@@ -270,24 +271,27 @@ def get_geodataframe(identifier):
     # -------------------
 
     base_url = (
-        pyku_resources
-        .get('polygons')
-        .get(identifier)
-        .get('base_url', None)
+        PYKU_RESOURCES.get_value('resources',
+                                 'polygons',
+                                 identifier,
+                                 'base_url',
+                                 default=None)
     )
 
     archive_file = (
-        pyku_resources
-        .get('polygons')
-        .get(identifier)
-        .get('archive_file', None)
+        PYKU_RESOURCES.get_value('resources',
+                                 'polygons',
+                                 identifier,
+                                 'archive_file',
+                                 default=None)
     )
 
     target_file = (
-        pyku_resources
-        .get('polygons')
-        .get(identifier)
-        .get('target_file', None)
+        PYKU_RESOURCES.get_value('resources',
+                                 'polygons',
+                                 identifier,
+                                 'target_file',
+                                 default=None)
     )
 
     # Cases where polygons are built on-the-fly from other polygons
@@ -693,7 +697,7 @@ def _get_cftime_data():
     # Get the pyku data directory
     # --------------------------
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     # Create pooch installer
     # ----------------------
@@ -745,7 +749,7 @@ def _get_tas_hurs_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -807,7 +811,7 @@ def _get_tas_ps_huss_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -871,7 +875,7 @@ def _get_ps_tdew_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -945,7 +949,7 @@ def _get_low_res_hourly_tas_data():
     # Get the pyku data directory
     # --------------------------
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     # Create pooch installer
     # ----------------------
@@ -1045,7 +1049,7 @@ def _get_icon_grid_file():
     checksum = \
         "de22bb247525166865cdb8c396d3c39fecfadbc04cb613ced040074b60354c16"
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1084,7 +1088,7 @@ def _get_icon_grib_files():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1135,7 +1139,7 @@ def _get_small_tas_dataset():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1198,7 +1202,7 @@ def _get_hyras_tas_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1265,7 +1269,7 @@ def _get_hyras_pr_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1335,7 +1339,7 @@ def _get_monthly_hyras_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1400,7 +1404,7 @@ def _get_monthly_hyras_files():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1447,7 +1451,7 @@ def _get_daily_cosmo_rea6_data():
     import pooch
     from filelock import FileLock
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     pooch_installer = pooch.create(
         path=pyku_data_dir,
@@ -1530,7 +1534,7 @@ def _get_hostrada_data():
     # Get the pyku data directory
     # --------------------------
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     # Create pooch installer
     # ----------------------
@@ -1606,7 +1610,7 @@ def _get_CCCma_CanESM2_Amon_world():
     import s3fs
     import warnings
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     s3_paths = [
         "s3://esgf-world/CMIP6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/Amon/"
@@ -1654,7 +1658,7 @@ def _get_MPI_ESM1_2_HR_tas_data():
     import s3fs
     import warnings
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     s3_path = (
         "s3://esgf-world/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/"
@@ -1695,7 +1699,7 @@ def _get_MPI_ESM1_2_HR_pr_data():
     import s3fs
     import warnings
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     s3_path = (
         "s3://esgf-world/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/"
@@ -1732,7 +1736,7 @@ def _get_global_data():
     import s3fs
     import warnings
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     s3_path = (
         "s3://esgf-world/CMIP6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/"
@@ -1768,7 +1772,7 @@ def _get_monthly_eurocordex_data():
     import s3fs
     import warnings
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     s3_path = (
         "s3://euro-cordex/CMIP5/cordex/output/EUR-11/SMHI/MPI-M-MPI-ESM-LR/"
@@ -1802,7 +1806,7 @@ def _get_GCM_CanESM5_data():
     import s3fs
     import warnings
 
-    pyku_data_dir = Path(pyku_config.get('data_dir'))
+    pyku_data_dir = Path(PYKU_CONFIG.get('data_dir'))
 
     s3_path = (
         "s3://euro-cordex/CMIP5/cordex-reklies/output/EUR-11/CLMcom/"

--- a/pyku/timekit.py
+++ b/pyku/timekit.py
@@ -4,9 +4,7 @@
 Functions for dealing with time
 """
 
-
-from . import logger
-from . import meta_dict
+from pyku import logger, PYKU_RESOURCES
 
 
 def date_range(*args, **kwargs):
@@ -287,11 +285,11 @@ def resample_datetimes(ds, how=None, frequency=None, complete=False):
 
         elif how in ['min', 'minimum']:
             message = f"{varname}: min not implemented"
-            logger.warn(message)
+            logger.warning(message)
 
         elif how in ['max', 'maximum']:
             message = f"{varname}: max not implemented"
-            logger.warn(message)
+            logger.warning(message)
 
         elif how in ['sum']:
             output_cell_methods = 'time: sum'
@@ -401,7 +399,7 @@ def resample_datetimes(ds, how=None, frequency=None, complete=False):
 
     else:
         message = f"frequency {frequency} not a CMOR standard."
-        logger.warn(message)
+        logger.warning(message)
 
         ds_out.attrs['frequency'] = to_offset(frequency).freqstr
 
@@ -476,7 +474,8 @@ def to_gregorian_calendar(ds, add_missing=False):
     # ---------------------------------------------------------
 
     time_bounds_exist = any(
-        elem in ds.keys() for elem in meta_dict['temporal_bounds']
+        elem in ds.keys() for elem in
+        PYKU_RESOURCES.get_value('metadata', 'temporal_bounds')
     )
 
     if time_bounds_exist:
@@ -741,7 +740,7 @@ def select_common_datetimes(ds1, ds2):
             "first 3 time labels of the second dataset are "
             f"{ds2.time.values[0:3]}"
         )
-        logger.warn(message)
+        logger.warning(message)
 
     # Select common datetimes
     # -----------------------
@@ -793,7 +792,8 @@ def filter_incomplete_datetimes(ds, frequency=None, freq_resampled=None):
             "Use parameter 'frequency' and set 'freq_resampled to None'")
 
     if freq_resampled is not None:
-        logger.warn("'freq_resampled' is deprecated. Please use 'frequency'")
+        logger.warning("'freq_resampled' is deprecated. "
+                       " Please use 'frequency'")
 
     if frequency is not None:
         freq_resampled = frequency

--- a/testing/core/config_provider_test.py
+++ b/testing/core/config_provider_test.py
@@ -1,0 +1,32 @@
+import unittest
+
+
+class TestConfigProvider(unittest.TestCase):
+
+    def test_config_initialization(self):
+        from pyku.core.config_provider import PykuConfigProviderSingleton
+
+        config_provider = PykuConfigProviderSingleton
+
+        config_attributes = [
+            'pre_existing_data_dir',
+            'data_dir',
+            'cache_dir',
+            'repo_data_dir',
+            'default_data_dir',
+            'downloaders',
+        ]
+        for attr in config_attributes:
+            self.assertIn(attr, config_provider.config)
+
+    def test_get_set_config(self):
+        from pyku.core.config_provider import PykuConfigProviderSingleton
+
+        config_provider = PykuConfigProviderSingleton
+
+        # Test setting a config value
+        config_provider.set('test_key', 'test_value')
+        self.assertEqual(config_provider.get('test_key'), 'test_value')
+
+        # Test getting a non-existing key returns None
+        self.assertIsNone(config_provider.get('non_existing_key'))

--- a/testing/core/resource_provider_test.py
+++ b/testing/core/resource_provider_test.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+unittests for resource manager module
+"""
+import unittest
+from unittest.mock import patch, mock_open
+import importlib.resources
+
+import yaml
+
+# Add the src directory to the Python path
+from pyku.core.resource_provider import PykuResourceProvider
+
+
+class TestImportlibResource(unittest.TestCase):
+    def test_get_resource_link(self):
+        # This is a simple test to check if importlib.resource does what it
+        # is supposed to do
+        area_file = importlib.resources.files('pyku.etc') / 'areas.yaml'
+        self.assertTrue(area_file.parts[-1].endswith('areas.yaml'))
+
+    def test_load_area_file(self):
+        #
+        from pyresample.area_config import load_area
+        from pyresample.geometry import AreaDefinition
+
+        area_file = importlib.resources.files('pyku.etc') / 'areas.yaml'
+        area_def = load_area(area_file, 'HYR-LAEA-5')
+        self.assertIsInstance(area_def, AreaDefinition)
+
+
+class TestPykuResourceProvider(unittest.TestCase):
+    def setUp(self):
+        self.pseudo_file = """Test1:
+    test2:
+        key : value
+"""
+        self.pseudo_dict = yaml.safe_load(self.pseudo_file)
+
+    @patch('builtins.open')
+    @patch('pathlib.Path.exists')
+    def test_load_resource_success(self, mock_exists, mock_open_file):
+        """Test successful YAML resource loading."""
+        # Setup mocks
+        mock_exists.return_value = True
+        mock_file = mock_open(read_data=self.pseudo_file)
+        mock_open_file.return_value = mock_file.return_value
+
+        # Create ResourceManager and load resource
+        resource_provider = PykuResourceProvider()
+        result = resource_provider.load_resource("test_file")
+
+        # Assertions - compare with expected parsed result
+        self.assertEqual(result, self.pseudo_dict)
+        mock_exists.assert_called_once_with()
+        mock_open_file.assert_called_once()
+
+        # check caching... a second call should not open the file again
+        result_cache = resource_provider.load_resource("test_file")
+        self.assertEqual(result, result_cache)
+        mock_open_file.assert_called_once()
+        self.assertEqual(mock_open_file.call_count, 1)
+
+        # but if cache got cleared it should get called a second time!
+        resource_provider.clear_cache()
+        result = resource_provider.load_resource("test_file")
+        self.assertEqual(mock_open_file.call_count, 2)
+
+    @patch('builtins.open')
+    @patch('pathlib.Path.exists')
+    def test_get_keys(self, mock_exists, mock_open_file):
+        mock_exists.return_value = True
+        mock_file = mock_open(read_data=self.pseudo_file)
+        mock_open_file.return_value = mock_file.return_value
+
+        # Create ResourceManager and load resource
+        resource_provider = PykuResourceProvider()
+        _ = resource_provider.load_resource("test_file")
+
+        keys = resource_provider.get_keys('test_file')
+        self.assertEqual(list(keys), ['Test1'])
+
+        keys = resource_provider.get_keys('test_file', 'Test1')
+        self.assertEqual(list(keys), ['test2'])
+
+    @patch('builtins.open')
+    @patch('pathlib.Path.exists')
+    def test_get_value(self, mock_exists, mock_open_file):
+        mock_exists.return_value = True
+        mock_file = mock_open(read_data=self.pseudo_file)
+        mock_open_file.return_value = mock_file.return_value
+
+        # Create ResourceManager and load resource
+        resource_provider = PykuResourceProvider()
+        _ = resource_provider.load_resource("test_file")
+
+        res = resource_provider.get_value('test_file', 'Test1')
+        self.assertEqual(res, self.pseudo_dict['Test1'])
+        res = resource_provider.get_value(
+                    'test_file', 'Test1', 'test2')
+        self.assertEqual(res, self.pseudo_dict['Test1']['test2'])
+
+        res = resource_provider.get_value(
+                    'test_file', 'Test1', 'test2', 'key')
+        self.assertEqual(res, 'value')
+
+    @patch('builtins.open')
+    @patch('pathlib.Path.exists')
+    def test_get_value_default_kw(self, mock_exists, mock_open_file):
+        mock_exists.return_value = True
+        mock_file = mock_open(read_data=self.pseudo_file)
+        mock_open_file.return_value = mock_file.return_value
+
+        # Create ResourceManager and load resource
+        resource_provider = PykuResourceProvider()
+        _ = resource_provider.load_resource("test_file")
+        # Calling a non-existent key should raise an error!
+        with self.assertRaises(KeyError):
+            resource_provider.get_value('test_file', 'Test3')
+
+        # Return default value when given as kw
+        default = resource_provider.get_value('test_file',
+                                              'Test3',
+                                              default='default')
+        self.assertEqual(default, 'default')
+
+        # Ensure that default None is possible and returns right type
+        default = resource_provider.get_value('test_file',
+                                              'Test3',
+                                              default=None)
+        self.assertIsNone(default)
+
+    def test_real_resources(self):
+        resource_provider = PykuResourceProvider()
+        base_colours = resource_provider.load_resource("base_colours")
+
+        keys = resource_provider.get_keys('base_colours')
+        self.assertEqual(base_colours.keys(), keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This MR implements
- a centralised resource provider that allows direct access to yaml files in /etc within modules, rather than reading all files during init (and keeping them as globals).
- a centralised config provider that stores and serves pyku related configurations (which is currently mainly data_dir).
- It starts to reduces the init file to prepare quicker initialisation times and lazy import of stuff.

It furthermore changes pyku-wide relative imports to absolute imports. It furthermore changes all occurrences of the deprecated `logger.warn` into `logger.warning`

An instance of `class::PykuResourceProvider` works as a main source of resources within pyku. It...

- ... has a method to `load_resource` which reads a yaml file (given as argument without extension) and returns it as a dictionary as well as adds it to a internal cache. If the resource is already in the cache, it doesnt get read again.
- ... has a method to `get_value`, which uses load_resource to retrieve the base directory, as well as allows to give an arbitraty number of ordered args that would get walked through the (dictionary) hierarchy of the resource file. A default kwargument can be given, when a certain default value should be returned for non existing keys.
- ... has a method to `get_keys`, which uses `get_value` but instead of returning the dictionary/value it returns the keys on the given level/hierarchy.

Examples for usage:

```python
from pyku import PYKU_RESOURCES
base_colours = PYKU_RESOURCE.load_resource('base_colours')
temp_ano_colours = PYKU_RESOURCE.get_value('base_colours','temp_ano','colours_hex')
temp_ano_colours = PYKU_RESOURCE.get_value('base_colours','temp_ano','colours_hex',default=[])
available_colors = PYKU_RESOURCE.get_keys('base_colours')
```

An instance of `class::PykuConfigProvider` initialises, sanity checks and serves configurations. It has mainly a config attribute accessible with get and set methods. `data_dir` and `cache_dir` additionally have properties and a setter.

```python
from pyku import PYKU_CONFIG
PYKU_CONFIG.get('data_dir')
PYKU_CONFIG.data_dir
PYKU_CONFIG.data_dir = '/some/new/directory'  # not sanity checked
```
we could think of including `PYKU_CONFIG` as `config` in `pyku.__init__` rather than `PYKU_CONFIG`, although using config is usually not bulletproof since easily overwritten in runtime or interactive sessions.