### PR TITLE
Hotfix/config

### DIFF
--- a/pyku/core/config_provider.py
+++ b/pyku/core/config_provider.py
@@ -32,6 +32,7 @@ class PykuConfigProvider:
         # Set the pyku configuration
         self.config = {
             'pre_existing_data_dir': pre_existing_data_dir,
+            '_data_dir': _data_dir,
             'data_dir': data_dir,
             'cache_dir': _cache_dir,
             'repo_data_dir': Path(__file__).parent / 'data',

--- a/pyku/resources.py
+++ b/pyku/resources.py
@@ -49,9 +49,9 @@ def _warn_if_default_data_dir():
     """
 
     from pathlib import Path
-    from . import _data_dir
+    from pyku import PYKU_CONFIG
 
-    default_data_dir = Path(_data_dir).resolve()
+    default_data_dir = Path(PYKU_CONFIG.get('_data_dir')).resolve()
     current_path = Path(PYKU_CONFIG.get('data_dir'))
     current_data_dir = Path(current_path).resolve()
 


### PR DESCRIPTION
A legacy usage of _data_dir directly from pyku.__init__ has been removed. 
This needed the addition of `_data_dir` to the PYKU_CONFIG since it is used for the default data directory warning in the resource module. 
