### PR TITLE
Include CLIX tests

### DIFF
--- a/doc/plugins/climate_indicators/new_indicators.rst
+++ b/doc/plugins/climate_indicators/new_indicators.rst
@@ -40,70 +40,68 @@ generic `xclim` function embedded as a Python wrapper, which is then linked
 within the YAML configuration file.
 
 .. code-block:: python
+    @declare_units(
+        pr="[precipitation]",
+	tas="[temperature]",
+	pr_thresh="[precipitation]",
+	tas_thresh="[temperature]",
+    )
+    def potsnowday(
+        pr: xr.DataArray,
+	tas: xr.DataArray,
+	pr_thresh: Quantified = "1 mm/d",
+	tas_thresh: Quantified = "2 degC",
+	op_pr: Literal[">", "gt", ">=", "ge", "<", "lt", "<=", "le"] = ">=",
+	op_tas: Literal[">", "gt", ">=", "ge", "<", "lt", "<=", "le"] = "<=",
+	freq: str = "YS",
+    ) -> xr.DataArray:
+    """
+    Number of days with precipitation above threshold and temperature
+    below threshold.
 
-   @declare_units(pr="[precipitation]", tas="[temperature]")
-   def potsnowdays(
-           pr: xr.DataArray,
-           tas: xr.DataArray,
-           thresh_pr: Quantified = "1.0 mm/day",
-           thresh_tas: Quantified = "2 degC",
-           freq: str = "YS",
-           op_pr: Literal[">", "gt", ">=", "ge"] = ">=",
-           op_tas: Literal["<", "lt", "<=", "le"] = "<=",
-           var_reducer: Literal["all", "any"] = "all",
-           constrain_pr: Sequence[str] | None = None,
-           constrain_tas: Sequence[str] | None = None,
-   ) -> xr.DataArray:
-       r"""
-       Potential Snow Days.
+    Number of days when precipitation is greater or equal to some threshold,
+    and temperatures are colder than some threshold. This can be used for
+    example to identify days with the potential for freezing rain or icing
+    conditions.
 
-       The number of potential snow days, where daily precipitation is
-       above or equal to ``thresh_pr`` (default: 1 mm/day) and daily mean
-       temperature is below or equal to ``thresh_tas`` (default: 2 degC).
+    Parameters
+    ----------
+    pr : xarray.DataArray
+        Mean daily precipitation flux.
+    tas : xarray.DataArray
+        Daily mean, minimum or maximum temperature.
+    pr_thresh : Quantified
+        Precipitation threshold to exceed.
+    tas_thresh : Quantified
+        Temperature threshold not to exceed.
+    freq : str
 
-       Parameters
-       ----------
-       pr : xarray.DataArray
-           Daily precipitation amount.
-       tas : xarray.DataArray
-           Daily mean temperature.
-       thresh_pr : Quantified
-           Precipitation threshold.
-       thresh_tas : Quantified
-           Temperature threshold.
-       freq : str
-           Resampling frequency defining the periods as defined in :ref:`timeseries.resampling`.
-       op_pr : {">", "gt", ">=", "ge"}
-           Logical operator for precipitation comparison (e.g., ``arr > thresh``).
-       op_tas : {"<", "lt", "<=", "le"}
-           Logical operator for temperature comparison (e.g., ``arr < thresh``).
-       var_reducer : {"all", "any"}
-           The condition must be fulfilled on *all* or *any* variables
-           for the period to be considered an occurrence.
-       constrain_pr : sequence of str, optional
-           Optionally allowed comparison operators for precipitation (`pr`).
-       constrain_tas : sequence of str, optional
-           Optionally allowed comparison operators for temperature (`tas`).
+    Returns
+    -------
+    xarray.DataArray, [time]
+        Count of days with high precipitation and low temperatures.
 
-       Returns
-       -------
-       xr.DataArray
-           The DataArray of counted occurrences of potential snow days.
-       """
+    Examples
+    --------
+    To compute the number of days with intense rainfall while minimum
+    temperatures dip below -0.2C:
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> tasmin = xr.open_dataset(path_to_tasmin_file).tasmin
+    >>> high_precip_low_temp(pr, tas=tasmin, pr_thresh="10 mm/d",
+    >>>                      tas_thresh="-0.2 degC")
+    """
+    pr_thresh = convert_units_to(pr_thresh, pr, context="hydro")
+    tas_thresh = convert_units_to(tas_thresh, tas)
 
-       from xclim.indices.generic import bivariate_count_occurrences
-       from xclim.core.units import convert_units_to # Assuming this is the correct import path
+    constrain = (">", "<", ">=", "<=", "==", "!=")
+    cond = (
+        compare(pr, op_pr, pr_thresh, constrain) &
+        compare(tas, op_tas, tas_thresh, constrain)
+    )
 
-       # Convert units of DataArray and thresholds if necessary
-       pr = convert_units_to(pr, thresh_pr, context="hydro")
-       tas = convert_units_to(tas, thresh_tas)
+    out = cond.resample(time=freq).sum(dim="time")
+    return to_agg_units(out, pr, "count", deffreq="D")
 
-       return bivariate_count_occurrences(
-           data_var1=pr, data_var2=tas, freq=freq,
-           threshold_var1=thresh_pr, threshold_var2=thresh_tas,
-           op_var1=op_pr, op_var2=op_tas, var_reducer=var_reducer,
-           constrain_var1=constrain_pr, constrain_var2=constrain_tas,
-       )
 
 .. code-block:: yaml
 
@@ -113,12 +111,10 @@ within the YAML configuration file.
      units: days
      description: "The number of potential snow days, where daily precipitation is above or equal {thresh_pr} and daily mean temperature is below or equal {thresh_tas}."
      cell_methods: 'time: mean within days time: sum over days'
-     xclim_function: pyku.indices.clix_custom_indicators.potsnowdays
+     function: pyku.indices.clix_custom_indicators.potsnowdays
      default_parameters:
        thresh_pr: 1 mm/day
        thresh_tas: 2 degC
        op_pr: '>='
        op_tas: '<='
-       var_reducer: 'all'
-
 

--- a/pyku/clix/cli.py
+++ b/pyku/clix/cli.py
@@ -10,17 +10,17 @@ from datetime import datetime
 from jsonargparse import ArgumentParser
 from jsonargparse.typing import register_type
 from pandas.tseries.frequencies import to_offset
-from pint import Quantity
 from rapidfuzz import process
-from xclim.core import Quantified  # register new type
-from xclim.core.units import units
 
 from pyku.clix import indicator_data
 from pyku.clix.manager import (
     get_indicator_description,
     load_function,
+    fix_annotations,
     replace_description_with_values,
     update_default_args,
+    QuantityStr,
+    parse_quantity,
 )
 
 
@@ -174,14 +174,7 @@ def percent_0_to_100(val: str) -> float:
     return val
 
 
-def parse_quantity(val: str) -> Quantity:
-    try:
-        return units.Quantity(val)
-    except Exception as e:
-        raise ValueError(f"Invalid quantity '{val}': {e}")
-
-
-register_type(Quantified, str, parse_quantity)
+register_type(QuantityStr, str, parse_quantity)
 
 
 def build_parser():
@@ -192,8 +185,7 @@ def build_parser():
         env_prefix='CLIX'
     )
 
-    # Create a mandatory group (mg) for input arguments
-    # mg = parser.add_argument_group(
+    # Create a mandatory input group (ig) for input arguments
     ig = parser.add_argument_group(
         'Mandatory input arguments',
     )
@@ -304,15 +296,15 @@ def build_parser():
         required=True)
 
     for indicator, params in indicator_data.items():
-
         # Subparser for indicators
         indp = ArgumentParser()
-        fn = load_function(params['function'])
+        func = load_function(params['function'])
+        func = fix_annotations(func)
 
         # Add arguments based on the specified function
         # Skips required arguments that represent input DataArrays
         indp.add_function_arguments(
-            fn,
+            func,
             skip=['tas', 'pr', 'tasmax', 'tasmin', 'sfcWind', 'rsds',
                   'tas_per', 'pr_per', 'tasmax_perc', 'tasmin_per',
                   'data1', 'data2', 'data_var1', 'data_var2', 'freq'],
@@ -328,6 +320,7 @@ def build_parser():
         desc = get_indicator_description(indicator)
         desc = replace_description_with_values(indp, desc)
         indp.description = desc
+
         subs.add_subcommand(indicator, indp, help=desc)
 
     return parser

--- a/pyku/clix/custom_indicators.py
+++ b/pyku/clix/custom_indicators.py
@@ -10,8 +10,12 @@ from typing import Literal, Sequence
 
 import xarray as xr
 from xclim.core import Quantified
-from xclim.core.calendar import resample_doy
-from xclim.core.units import convert_units_to, declare_units
+from xclim.core.calendar import resample_doy, adjust_doy_calendar
+from xclim.core.units import (
+    convert_units_to,
+    declare_units,
+    to_agg_units
+)
 from xclim.indices.generic import compare, select_resample_op
 from xclim.indices import (
     dry_spell_frequency,
@@ -22,8 +26,8 @@ from xclim.indices import (
 
 @declare_units(
     pr="[precipitation]",
-    thresh_low="[precipitation]",
-    thresh_high="[temperature]",
+    thresh_low="[length]",
+    thresh_high="[length]",
 )
 def wet_spell_frequency_bounded_thresh(
     pr: xr.DataArray,
@@ -343,19 +347,16 @@ def prcpertot(
 
     import numpy as np
 
-    pr = convert_units_to(pr, "mm", context="hydro")
-    pr_per = convert_units_to(pr_per, "mm", context="hydro")
+    pr_per = convert_units_to(pr_per, pr, context="hydro")
 
     tp = pr_per
     if "dayofyear" in pr_per.coords:
         # Create time series out of doy values.
         tp = resample_doy(tp, pr)
 
-    constrain = (">", ">=")
-
     # Compute the days when precip is over the percentile threshold.
     over = (
-        pr.where(compare(pr, op, tp, constrain), np.nan)
+        pr.where(compare(pr, op, tp, constrain=(">", ">=")), np.nan)
         .resample(time=freq)
         .sum(dim="time")
     )
@@ -448,96 +449,84 @@ def potevap(
 @declare_units(
     pr="[precipitation]",
     tas="[temperature]",
-    thresh_pr="[precipitation]",
-    thresh_tas="[temperature]",
+    pr_thresh="[precipitation]",
+    tas_thresh="[temperature]",
 )
-def potsnowdays(
+def potsnowday(
     pr: xr.DataArray,
     tas: xr.DataArray,
-    thresh_pr: Quantified = "1.0 mm/day",
-    thresh_tas: Quantified = "2 degC",
+    pr_thresh: Quantified = "1 mm/d",
+    tas_thresh: Quantified = "2 degC",
+    op_pr: Literal[">", "gt", ">=", "ge", "<", "lt", "<=", "le"] = ">=",
+    op_tas: Literal[">", "gt", ">=", "ge", "<", "lt", "<=", "le"] = "<=",
     freq: str = "YS",
-    op_pr: Literal[">", "gt", ">=", "ge"] = ">=",
-    op_tas: Literal["<", "lt", "<=", "le"] = "<=",
-    var_reducer: Literal["all", "any"] = "all",
-    constrain_pr: Sequence[str] | None = None,
-    constrain_tas: Sequence[str] | None = None,
 ) -> xr.DataArray:
-    r"""
-    Potential Snow Days.
+    """
+    Number of days with precipitation above threshold and temperature
+    below threshold.
 
-    The number of potential snow days, where the min precipitation is
-    above or equal thresh_pr (default: 1mm/day) and mean
-    temperature is below or equal thresh_tas (default 2 degC)."
+    Number of days when precipitation is greater or equal to some threshold,
+    and temperatures are colder than some threshold. This can be used for
+    example to identify days with the potential for freezing rain or icing
+    conditions.
 
     Parameters
     ----------
-    pr : xr.DataArray
-        Minimum daily Temperature.
-    tas : xr.DataArray
-        Maximum daily Temperature.
-    thresh_pr : Quantified
-        Threshold for data pr.
-    thresh_tas : Quantified
-        Threshold for data tas.
+    pr : xarray.DataArray
+        Mean daily precipitation flux.
+    tas : xarray.DataArray
+        Daily mean, minimum or maximum temperature.
+    pr_thresh : Quantified
+        Precipitation threshold to exceed.
+    tas_thresh : Quantified
+        Temperature threshold not to exceed.
     freq : str
-        Resampling frequency defining the periods as defined in
-        :ref:`timeseries.resampling`.
-    op_pr : {">", "gt", ">=", "ge"}
-        Logical operator for data pr e.g. arr > thresh.
-    op_tas : {"<", "lt", "<=", "le"}
-        Logical operator for data tas e.g. arr > thresh.
-    var_reducer : {"all", "any"}
-        The condition must either be fulfilled on *all* or *any* variables
-        for the period to be considered an occurrence.
-    constrain_pr : sequence of str, optional
-        Optionally allowed comparison operators for pr.
-    constrain_tas : sequence of str, optional
-        Optionally allowed comparison operators for tas.
+        Resampling frequency.
 
     Returns
     -------
-    xr.DataArray
-        The DataArray of counted occurrences of potential snow days.
+    xarray.DataArray, [time]
+        Count of days with high precipitation and low temperatures.
+
+    Examples
+    --------
+    To compute the number of days with intense rainfall while minimum
+    temperatures dip below -0.2C:
+    >>> pr = xr.open_dataset(path_to_pr_file).pr
+    >>> tasmin = xr.open_dataset(path_to_tasmin_file).tasmin
+    >>> high_precip_low_temp(pr, tas=tasmin, pr_thresh="10 mm/d",
+    >>>                      tas_thresh="-0.2 degC")
     """
+    pr_thresh = convert_units_to(pr_thresh, pr, context="hydro")
+    tas_thresh = convert_units_to(tas_thresh, tas)
 
-    from xclim.indices.generic import bivariate_count_occurrences
-
-    # Convert units of DataArray and thresholds if necessary
-    pr = convert_units_to(pr, thresh_pr, context="hydro")
-    tas = convert_units_to(tas, thresh_tas)
-
-    return bivariate_count_occurrences(
-        data_var1=pr,
-        data_var2=tas,
-        freq=freq,
-        threshold_var1=thresh_pr,
-        threshold_var2=thresh_tas,
-        op_var1=op_pr,
-        op_var2=op_tas,
-        var_reducer=var_reducer,
-        constrain_var1=constrain_pr,
-        constrain_var2=constrain_tas,
+    constrain = (">", "<", ">=", "<=", "==", "!=")
+    cond = (
+        compare(pr, op_pr, pr_thresh, constrain) &
+        compare(tas, op_tas, tas_thresh, constrain)
     )
+
+    out = cond.resample(time=freq).sum(dim="time")
+    return to_agg_units(out, pr, "count", deffreq="D")
 
 
 @declare_units(
     pr="[precipitation]",
     tasmax="[temperature]",
     thresh_pr="[precipitation]",
-    thresh_tasmax_low="[temperature]",
-    thresh_tasmax_high="[temperature]",
+    thresh_tasmax_lower="[temperature]",
+    thresh_tasmax_higher="[temperature]",
 )
 def tourism_days(
     pr: xr.DataArray,
     tasmax: xr.DataArray,
     thresh_pr: Quantified = "0.5 mm/day",
-    thresh_tasmax_low: Quantified = "15 degC",
-    thresh_tasmax_high: Quantified = "30 degC",
+    thresh_tasmax_lower: Quantified = "15 degC",
+    thresh_tasmax_higher: Quantified = "30 degC",
     freq: str = "YS",
     op_pr: Literal["<", "lt", "<=", "le"] = "<",
-    op_tasmax_low: Literal[">", "gt", ">=", "ge"] = ">=",
-    op_tasmax_high: Literal["<", "lt", "<=", "le"] = "<=",
+    op_tasmax_lower: Literal[">", "gt", ">=", "ge"] = ">=",
+    op_tasmax_higher: Literal["<", "lt", "<=", "le"] = "<=",
 ) -> xr.DataArray:
     r"""
     Tourism day index.
@@ -550,24 +539,24 @@ def tourism_days(
 
     Parameters
     ----------
-    pr : xr.DataArray
+    pr: xr.DataArray
         Daily precipitation.
-    tasmax : xr.DataArray
+    tasmax: xr.DataArray
         Maximum daily Temperature.
-    thresh_pr : Quantified
+    thresh_pr: Quantified
         Threshold for data pr.
-    thresh_tasmax_low : Quantified
+    thresh_tasmax_lower: Quantified
         Lower threshold for data tasmax.
-    thresh_tasmax_high : Quantified
+    thresh_tasmax_higher: Quantified
         Higher threshhold for data tasmax
-    freq : str
+    freq: str
         Resampling frequency defining the periods as defined in
         :ref:`timeseries.resampling`.
-    op_pr : {"<", "lt", "<=", "le"}
+    op_pr: {"<", "lt", "<=", "le"}
         Logical operator for data pr e.g. arr < thresh_pr.
-    op_tasmax_low : {">", "gt", ">=", "ge"}
+    op_tasmax_lower: {">", "gt", ">=", "ge"}
         Logical operator for data tasmax e.g. arr > thresh_low.
-    op_tasmax_high : {"<", "lt", "<=", "le"}
+    op_tasmax_higher: {"<", "lt", "<=", "le"}
         Logical operator for data tasmax e.g. arr < thresh_high.
 
     Returns
@@ -581,16 +570,18 @@ def tourism_days(
 
     # Convert units of DataArray and thresholds if necessary
     thresh_pr = convert_units_to(thresh_pr, pr, context="hydro")
-    thresh_tasmax_low = convert_units_to(thresh_tasmax_low, tasmax)
-    thresh_tasmax_high = convert_units_to(thresh_tasmax_high, tasmax)
+    thresh_tasmax_lower = convert_units_to(thresh_tasmax_lower, tasmax)
+    thresh_tasmax_higher = convert_units_to(thresh_tasmax_higher, tasmax)
 
     constrain_low = (">", ">=")
     constrain_high = ("<", "<=")
 
     cond = (
-        compare(pr, op_pr, thresh_pr, constrain_high)
-        & compare(tasmax, op_tasmax_low, thresh_tasmax_low, constrain_low)
-        & compare(tasmax, op_tasmax_high, thresh_tasmax_high, constrain_high)
+        compare(pr, op_pr, thresh_pr, constrain_high) &
+        compare(tasmax, op_tasmax_lower,
+                thresh_tasmax_lower, constrain_low) &
+        compare(tasmax, op_tasmax_higher,
+                thresh_tasmax_higher, constrain_high)
     )
 
     out = cond.resample(time=freq).sum()
@@ -598,7 +589,7 @@ def tourism_days(
     return to_agg_units(out, pr, "count", dim="time")
 
 
-@declare_units(sfcWind="[wind]")
+@declare_units(sfcWind="[speed]")
 def sfcWindp98(
     sfcWind: xr.DataArray,
     sfcWind_percentile: float = 98,
@@ -681,7 +672,8 @@ def percentile_grouped(
         FREQ_GROUP_MAP = {
             "MS": lambda t: t.dt.month.rename("month"),
             "YS": lambda t: xr.ones_like(t, dtype=int).rename("all"),
-            "QS-DEC": lambda t: t.dt.quarter.rename("quarter"),
+            "QS-DEC": lambda t: (((t.dt.month % 12) // 3) + 1).rename(
+                "season"),
         }
         try:
             return FREQ_GROUP_MAP[freq](time)
@@ -689,17 +681,6 @@ def percentile_grouped(
             raise ValueError(
                 f"Unsupported climatology grouping frequency: {freq}"
             )  # noqa
-
-        # FREQ_TO_FUNC = {
-        #     "MS": assign_month,
-        #     "YS": assign_year,
-        #     "QS-DEC": assign_quarter,
-        # }
-
-        # try:
-        #     return FREQ_TO_FUNC[freq](time)
-        # except KeyError:
-        #     raise ValueError(f"Unsupported frequency for period assignment: {freq}")  # noqa
 
     if climatology:
         # Use grouping key like "month" or "season" based on group_freq
@@ -724,7 +705,7 @@ def percentile_grouped(
 
 
 def expand_percentiles_to_daily(
-    daily: xr.DataArray, per: xr.DataArray, freq: str
+        daily: xr.DataArray, per: xr.DataArray, freq: str
 ) -> xr.DataArray:
     """
     Expand a grouped percentile array (e.g., monthly) to match a daily
@@ -748,29 +729,44 @@ def expand_percentiles_to_daily(
 
     import xarray as xr
 
-    # Get group labels for each day based on the frequency
-    def get_group_labels(time, freq):
-        if freq == "MS":
-            return xr.DataArray(
-                time.dt.month, coords={"time": time}, dims="time"
-            )
-        elif freq == "QS-DEC":
-            return xr.DataArray(
-                time.dt.quarter, coords={"time": time}, dims="time"
-            )
-        elif freq == "YS":
-            return xr.DataArray(
-                [1] * time.size, coords={"time": time}, dims="time"
-            )
-        else:
-            raise ValueError(f"Unsupported frequency: {freq}")
+    if freq == "MS":
+        labels = daily.time.dt.month
+    elif freq == "QS-DEC":
+        # Compact mapping to climatological seasons
+        # (DJF=1, MAM=2, JJA=3, SON=4)
+        labels = ((daily.time.dt.month % 12) // 3) + 1
+    elif freq == "YS":
+        labels = xr.DataArray(
+            [1] * daily.time.size,
+            coords={"time": daily.time},
+            dims="time"
+        )
+    else:
+        raise ValueError
 
-    group_labels = get_group_labels(daily.time, freq)
+    doy = daily.time.dt.dayofyear
 
-    # Map daily values to corresponding percentile
-    per_expanded = per.sel(time=group_labels)
+    # Map percentiles to each day
+    tmp = per.sel(time=labels)
+    attrs = tmp.attrs
 
-    # Ensure time coordinate is set
-    per_expanded["time"] = daily["time"]
+    # Build new DataArray with DOY as dimension directly
+    per_doy = xr.DataArray(
+        tmp.data,
+        dims=("time",) + tmp.dims[1:],
+        coords={**tmp.coords, "dayofyear": ("time", doy.values)},
+        attrs=attrs
+    )
 
-    return per_expanded
+    # Now collapse to unique DOY axis
+    per_doy = per_doy.swap_dims({"time": "dayofyear"})
+    per_doy = per_doy.groupby("dayofyear").first()
+    per_doy.attrs = attrs
+
+    # Use adjust_doy_calendar (as in xclim)
+    if per_doy.dayofyear.max() == 366:
+        per_doy = adjust_doy_calendar(
+            per_doy.sel(dayofyear=(per_doy.dayofyear < 366)), daily
+        )
+
+    return per_doy

--- a/pyku/clix/manager.py
+++ b/pyku/clix/manager.py
@@ -13,7 +13,9 @@ from typing import Optional
 
 import xarray as xr
 import xclim
-from xclim.core.units import check_units
+from xclim.core.units import check_units, units
+
+from pint import Quantity
 
 from pyku import logger
 from pyku.clix import indicator_data
@@ -756,6 +758,50 @@ def load_function(func_path):
         raise ValueError(f"The function {func_name} does not exist in the {module} library!")  # noqa
 
     return getattr(module, func_name)
+
+
+class QuantityStr(str):
+    """
+    String wrapper to make jsonargparse treat quantities as simple CLI inputs,
+    while conversion to pint.Quantity is handled separately.
+    """
+    pass
+
+
+def parse_quantity(val: str) -> Quantity:
+    try:
+        return units.Quantity(val)
+    except Exception as e:
+        raise ValueError(f"Invalid quantity '{val}': {e}")
+
+
+def fix_annotations(func):
+    """
+    Fix annotations for jsonargparse by resolving string type hints and
+    replacing xclim's unsupported `Quantified` type with a CLI-compatible type.
+    """
+
+    from typing import get_type_hints, Literal
+    from xclim.core import Quantified, DayOfYearStr
+
+    hints = get_type_hints(
+        func,
+        globalns={**func.__globals__,
+                  "Quantified": Quantified,
+                  "DayOfYearStr": DayOfYearStr,
+                  "xarray": xr,
+                  "xr": xr,
+                  "Literal": Literal,
+                  },
+        include_extras=True,
+    )
+
+    func.__annotations__ = {
+        k: (QuantityStr if v is Quantified else v)
+        for k, v in hints.items()
+    }
+
+    return func
 
 
 def update_default_args(parser, default_params):

--- a/pyku/etc/climate_indicators.yaml
+++ b/pyku/etc/climate_indicators.yaml
@@ -1,9 +1,9 @@
 # Indicator yaml-file containing all relevant information on DWD indicators
-# All indicators are grouped in section relying upon the input parameter
-# i.e.: groups so far: temperature, precipitation and wind based indicators
-# In the future combined groups possible like: temperature+precipitation
+# All indicators are grouped in section relying upon the input parameter(s)
+# Indicators that rely on multiple input variables are reffered to
+# specific groups like e.g.: tasmax+tasmin
 
-temperature:
+tas:
   tmmean:
     standard_name: air_temperature
     long_name: Mean of daily temperature
@@ -11,41 +11,37 @@ temperature:
     cell_methods: 'time: mean within days time: mean over days'
     function: xclim.indices.tg_mean
 
-  tnge20:
-    standard_name: >
-      number_of_days_with_air_temperature_at_or_above_threshold
+  gsl5:
+    standard_name: growing_season_length
     long_name: >
-      Number of Tropical Nights (Tmin >= 20C)
-    units: '1'
-    cell_methods: 'time: minimum within days time: sum over days'
-    function: xclim.indices.tn_days_above
+      ETCCDI Growing Season Length (Tmean > 5C)
+    units: days
+    cell_methods: >
+      time: mean within days time: sum over days (between start and end of
+      growing season)
+    function: xclim.indices.growing_season_length
     default_parameters:
-      thresh: 20 degC
+      thresh: 5 degC
+      window: 6
+      mid_date: 07-01
       op: '>='
 
-  tnlt0:
-    standard_name: >
-      number_of_days_with_air_temperature_below_threshold
+  gsl10:
+    standard_name: growing_season_length
     long_name: >
-      Number of Frost Days (Tmin < 0C)
-    units: '1'
-    cell_methods: 'time: minimum within days time: sum over days'
-    function: xclim.indices.frost_days
+      ETCCDI Growing Season Length (Tmean > 10C)
+    units: days
+    cell_methods: >
+      time: mean within days time: sum over days (between start and end of
+      growing season)
+    function: xclim.indices.growing_season_length
     default_parameters:
-      thresh: 0 degC
+      thresh: 10 degC
+      window: 6
+      mid_date: 07-01
+      op: '>='
 
-  tnlt4:
-    standard_name: >
-      number_of_days_with_air_temperature_below_threshold
-    long_name: >
-      Number of Days with Tmin < 4C
-    units: '1'
-    cell_methods: 'time: minimum within days time: sum over days'
-    function: xclim.indices.tn_days_below
-    default_parameters:
-      thresh: 4 degC
-      op: <
-
+tasmax:
   txlt0:
     standard_name: >
       number_of_days_with_air_temperature_below_threshold
@@ -97,19 +93,6 @@ temperature:
       window: 1
       op: '>='
 
-  csdi:
-    standard_name: >
-      spell_length_with_air_temperature_below_threshold_for_minimum_duration
-    long_name: >
-      Cold Spell Duration Index, count of days with at least 6 consecutive
-      days when Tmin < 10th percentile
-    units: days
-    function: xclim.indices.cold_spell_duration_index
-    default_parameters:
-      window: 6
-      op: <
-      tasmin_per: 10
-
   wsdi:
     standard_name: >
       number_of_days_with_air_temperature_above_threshold_for_minimum_duration
@@ -121,21 +104,6 @@ temperature:
     default_parameters:
       window: 6
       op: '>'
-      tasmax_per: 90
-
-  tnmean:
-    standard_name: air_temperature
-    long_name: Mean daily minimum temperature
-    units: degC
-    cell_methods: 'time: minimum within days time: mean over days'
-    function: xclim.indices.tn_mean
-
-  tnmin:
-    standard_name: air_temperature
-    long_name: Minimum daily minimum temperature
-    units: degC
-    cell_methods: 'time: minimum within days time: minimum over days'
-    function: xclim.indices.tn_min
 
   txmean:
     standard_name: air_temperature
@@ -151,6 +119,95 @@ temperature:
     cell_methods: 'time: maximum within days time: maximum over days'
     function: xclim.indices.tx_max
 
+  txge30ge3d:
+    standard_name:
+      number_of_occurances_with_air_temperature_at_or_above_threshold_for_minimum_duration
+    long_name: >
+      Hot Spell Index, count of occurrences with at least 3 consecutive
+      days when Tmax >= 30C
+    units: '1'
+    function: xclim.indices.hot_spell_frequency
+    default_parameters:
+      thresh: 30 degC
+      window: 3
+      op: '>='
+
+  txge30ge6d:
+    standard_name:
+      number_of_occurances_with_air_temperature_at_or_above_threshold_for_minimum_duration
+    long_name: >
+      Hot Spell Index, count of occurrences with at least 6 consecutive
+      days when Tmax >= 30C
+    units: '1'
+    function: xclim.indices.hot_spell_frequency
+    default_parameters:
+      thresh: 30 degC
+      window: 6
+      op: '>='
+
+tasmin:
+  tnge20:
+    standard_name: >
+      number_of_days_with_air_temperature_at_or_above_threshold
+    long_name: >
+      Number of Tropical Nights (Tmin >= 20C)
+    units: '1'
+    cell_methods: 'time: minimum within days time: sum over days'
+    function: xclim.indices.tn_days_above
+    default_parameters:
+      thresh: 20 degC
+      op: '>='
+
+  tnlt0:
+    standard_name: >
+      number_of_days_with_air_temperature_below_threshold
+    long_name: >
+      Number of Frost Days (Tmin < 0C)
+    units: '1'
+    cell_methods: 'time: minimum within days time: sum over days'
+    function: xclim.indices.frost_days
+    default_parameters:
+      thresh: 0 degC
+
+  tnlt4:
+    standard_name: >
+      number_of_days_with_air_temperature_below_threshold
+    long_name: >
+      Number of Days with Tmin < 4C
+    units: '1'
+    cell_methods: 'time: minimum within days time: sum over days'
+    function: xclim.indices.tn_days_below
+    default_parameters:
+      thresh: 4 degC
+      op: <
+
+  csdi:
+    standard_name: >
+      spell_length_with_air_temperature_below_threshold_for_minimum_duration
+    long_name: >
+      Cold Spell Duration Index, count of days with at least 6 consecutive
+      days when Tmin < 10th percentile
+    units: days
+    function: xclim.indices.cold_spell_duration_index
+    default_parameters:
+      window: 6
+      op: <
+
+  tnmean:
+    standard_name: air_temperature
+    long_name: Mean daily minimum temperature
+    units: degC
+    cell_methods: 'time: minimum within days time: mean over days'
+    function: xclim.indices.tn_mean
+
+  tnmin:
+    standard_name: air_temperature
+    long_name: Minimum daily minimum temperature
+    units: degC
+    cell_methods: 'time: minimum within days time: minimum over days'
+    function: xclim.indices.tn_min
+
+tasmax+tasmin:
   txge30tnge20ge3d:
     standard_name:
       number_of_occurances_with_air_temperature_at_or_above_thresholds_for_minimum_duration
@@ -210,62 +267,7 @@ temperature:
       op: '>='
       window: 3
 
-  txge30ge3d:
-    standard_name:
-      number_of_occurances_with_air_temperature_at_or_above_threshold_for_minimum_duration
-    long_name: >
-      Hot Spell Index, count of occurrences with at least 3 consecutive
-      days when Tmax >= 30C
-    units: '1'
-    function: xclim.indices.hot_spell_frequency
-    default_parameters:
-      thresh: 30 degC
-      window: 3
-      op: '>='
-
-  txge30ge6d:
-    standard_name:
-      number_of_occurances_with_air_temperature_at_or_above_threshold_for_minimum_duration
-    long_name: >
-      Hot Spell Index, count of occurrences with at least 6 consecutive
-      days when Tmax >= 30C
-    units: '1'
-    function: xclim.indices.hot_spell_frequency
-    default_parameters:
-      thresh: 30 degC
-      window: 6
-      op: '>='
-
-  gsl5:
-    standard_name: growing_season_length
-    long_name: >
-      ETCCDI Growing Season Length (Tmean > 5C)
-    units: days
-    cell_methods: >
-      time: mean within days time: sum over days (between start and end of
-      growing season)
-    function: xclim.indices.growing_season_length
-    default_parameters:
-      thresh: 5 degC
-      window: 6
-      mid_date: 07-01
-      op: '>='
-
-  gsl10:
-    standard_name: growing_season_length
-    long_name: >
-      ETCCDI Growing Season Length (Tmean > 10C)
-    units: days
-    cell_methods: >
-      time: mean within days time: sum over days (between start and end of
-      growing season)
-    function: xclim.indices.growing_season_length
-    default_parameters:
-      thresh: 10 degC
-      window: 6
-      mid_date: 07-01
-      op: '>='
-
+tasmin+tasmax+tas:
   etphs:
     standard_name: potential_evapotranspiration
     long_name: Potential Evapotranspiration
@@ -274,7 +276,7 @@ temperature:
       Potential Evapotranspiration based on Hargreaves and Samani, 1985
     function: pyku.clix.custom_indicators.potevap
 
-precipitation:
+pr:
   cddxd:
     standard_name: dry_spell_frequency
     long_name: >
@@ -428,11 +430,11 @@ precipitation:
     standard_name: wet_spell_frequency
     long_name: >
       Number of wet periods where the accumulated precipitation is more or equal
-      than {thresh} mm/day over a period of at least consecutive {window} days
+      than {thresh} mm over a period of at least consecutive {window} days
     units: '1'
     function: xclim.indices.wet_spell_frequency
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: max
       window: 3
 
@@ -442,11 +444,11 @@ precipitation:
     units: '1'
     description: >
       The number of wet periods where the accumulated precipitation is more or
-      equal than {thres} mm/day over periods between {window_min} and
+      equal than {thres} mm over periods between {window_min} and
       {window_max} days
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_window
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: max
       window_min: 4
       window_max: 5
@@ -472,10 +474,10 @@ precipitation:
     cell_methods: 'time: count over spells'
     description: >
       The number of wet periods where the accumulated precipitation is greater
-      than or equal to 1 mm/day over periods between 12 and 13 days
+      than or equal to 1 mm over periods between 12 and 13 days
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_window
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: min
       window_min: 12
       window_max: 13
@@ -488,10 +490,10 @@ precipitation:
     cell_methods: 'time: count over spells'
     description: >
       The number of wet periods where the accumulated precipitation is greater
-      than or equal to 1 mm/day over periods between 10 and 11 days
+      than or equal to 1 mm over periods between 10 and 11 days
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_window
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: min
       window_min: 10
       window_max: 11
@@ -504,10 +506,10 @@ precipitation:
     cell_methods: 'time: count over spells'
     description: >
       The number of wet periods where the accumulated precipitation is greater
-      than or equal to 1 mm/day over periods between 8 and 9 days
+      than or equal to 1 mm over periods between 8 and 9 days
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_window
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: min
       window_min: 8
       window_max: 9
@@ -520,10 +522,10 @@ precipitation:
     cell_methods: 'time: count over spells'
     description: >
       The number of wet periods where the accumulated precipitation is greater
-      than or equal to 1 mm/day over periods between 6 and 7 days
+      than or equal to 1 mm over periods between 6 and 7 days
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_window
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: min
       window_min: 6
       window_max: 7
@@ -536,10 +538,10 @@ precipitation:
     cell_methods: 'time: count over spells'
     description: >
       The number of wet periods where the accumulated precipitation is greater
-      than or equal to 1 mm/day over periods between 4 and 5 days
+      than or equal to 1 mm over periods between 4 and 5 days
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_window
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
       op: min
       window_min: 4
       window_max: 5
@@ -556,7 +558,7 @@ precipitation:
       days'
     function: xclim.indices.wet_spell_max_length
     default_parameters:
-      thresh: 1 mm/day
+      thresh: 1 mm
 
   dd:
     standard_name: >
@@ -623,7 +625,7 @@ precipitation:
     cell_methods: 'time: sum within days'
     function: xclim.indices.wet_spell_frequency
     default_parameters:
-      thresh: 80 mm/day
+      thresh: 80 mm
       window: 1
       op: sum
 
@@ -635,7 +637,7 @@ precipitation:
     cell_methods: 'time: sum within days'
     function: xclim.indices.wet_spell_frequency
     default_parameters:
-      thresh: 90 mm/day
+      thresh: 90 mm
       window: 1
       op: sum
 
@@ -696,8 +698,8 @@ precipitation:
       {thresh_low} and max precipitation is below or equal {thresh_high}.
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_thresh
     default_parameters:
-      thresh_low: 30 mm  # Accumulated precipitation
-      thresh_high: 50 mm  # Accumulated precipitation
+      thresh_low: 30 mm
+      thresh_high: 50 mm
       window: 1
       op: sum
 
@@ -711,8 +713,8 @@ precipitation:
       {thresh_low} and max precipitation is below or equal {thresh_high}.
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_thresh
     default_parameters:
-      thresh_low: 40 mm  # Accumulated precipitation
-      thresh_high: 60 mm  # Accumulated precipitation
+      thresh_low: 40 mm
+      thresh_high: 60 mm
       window: 2
       op: sum
 
@@ -726,8 +728,8 @@ precipitation:
       {thresh_low} and max precipitation is below or equal {thresh_high}.
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_thresh
     default_parameters:
-      thresh_low: 50 mm  # Accumulated precipitation
-      thresh_high: 80 mm  # Accumulated precipitation
+      thresh_low: 50 mm
+      thresh_high: 80 mm
       window: 1
       op: sum
 
@@ -741,12 +743,12 @@ precipitation:
       {thresh_low} and max precipitation is below or equal {thresh_high}.
     function: pyku.clix.custom_indicators.wet_spell_frequency_bounded_thresh
     default_parameters:
-      thresh_low: 60 mm  # Accumulated precipitation
-      thresh_high: 90 mm  # Accumulated precipitation
+      thresh_low: 60 mm
+      thresh_high: 90 mm
       window: 2
       op: sum
 
-wind:
+sfcWind:
   sfcWindmean:
     standard_name: wind_speed
     long_name: Mean daily surface wind speed at 10m height
@@ -763,7 +765,7 @@ wind:
       98th percentile of the mean daily wind speed at 10 m above ground
     function: pyku.clix.custom_indicators.sfcWindp98
 
-radiation:
+rsds:
   rsdsmean:
     standard_name: surface_downwelling_shortwave_flux_in_air
     long_name: Mean of daily surface net shortwave radiation
@@ -771,25 +773,23 @@ radiation:
     description: Mean of daily surface net shortwave radiation
     function: pyku.clix.custom_indicators.rsds_mean
 
-precipitation+temperature:
-
+pr+tas:
   rge1mmtmle2:
     standard_name: number_of_potential_snow_days
     long_name: Potential snow days
     units: days
     description: >
       The number of potential snow days, where the min precipitation is
-      above or equal {thresh_pr} and mean temperature is below or equal
-      {thresh_tas}.
+      above or equal {thresh_pr} and mean temperature is below {thresh_tas}.
     cell_methods: 'time: sum (pr) or mean within days time: sum over days'
-    function: pyku.clix.custom_indicators.potsnowdays
+    function: pyku.clix.custom_indicators.potsnowday
     default_parameters:
-      thresh_pr: 1 mm/day
-      thresh_tas: 2 degC
+      pr_thresh: 1 mm/day
+      tas_thresh: 2 degC
       op_pr: '>='
-      op_tas: <=
-      var_reducer: all
+      op_tas: '<='
 
+pr+tasmax:
   rlt1mmtxge15txle30:
     standard_name: number_of_tourism_days
     long_name: Tourism days
@@ -805,9 +805,9 @@ precipitation+temperature:
     default_parameters:
       thresh_pr: 0.5 mm/day
       thresh_tasmax_lower: 15 degC
-      thresh_tasmax_upper: 30 degC
+      thresh_tasmax_higher: 30 degC
       op_pr: <
       op_tasmax_lower: '>='
-      op_tasmax_upper: <=
+      op_tasmax_higher: <=
     global_attrs:
-      input: 'data1: tasmax, data2: pr'
+      input: 'data1: pr, data2: tasmax'

--- a/pyku/resources.py
+++ b/pyku/resources.py
@@ -1838,15 +1838,19 @@ def _get_fake_cmip6_data():
     return ds
 
 
-def generate_fake_cmip6_data(ntime=1, nlat=180, nlon=360, freq='D'):
+def generate_fake_cmip6_data(variable='tas', ntime=1, nlat=180,
+                             nlon=360, freq='D', seed=42):
     """
     Generate fake cmip6 data for testing
 
     Arguments:
+        variable (str): Variable name (one of ["tas", "tasmax",
+            "tasmin", "pr", "sfcWind", "rsds"])
         ntime (int): Number of years
         nlat (int): Number of latitudes
         nlon (int): Number of longitudes
         freq (str): Frequency of the time dimension
+        seed (int): Random seed for reproducibility
 
     Returns:
         :class:`xarray.Dataset`: Fake CMIP6 dataset
@@ -1856,6 +1860,8 @@ def generate_fake_cmip6_data(ntime=1, nlat=180, nlon=360, freq='D'):
     import numpy as np
     import xarray as xr
     import pandas as pd
+
+    np.random.seed(seed)
 
     lat = np.linspace(-90, 90, nlat)
     lon = np.linspace(-180, 180, nlon)
@@ -1868,13 +1874,53 @@ def generate_fake_cmip6_data(ntime=1, nlat=180, nlon=360, freq='D'):
                          freq=freq)
     dayofyear = time.dayofyear.values
 
-    temperature = (
-        15
-        + 10 * np.sin(np.radians(lat[:, None, None]))
-             * np.cos(np.radians(lon[None, :, None]))
-        + 5 * np.sin(2 * np.pi * (dayofyear / 365.0))[None, None, :]
-        + np.random.randn(len(lat), len(lon), len(time)) * 2
+    # base spatial + seasonal signal
+    seasonal_cycle = np.sin(2 * np.pi * (dayofyear / 365.0))[None, None, :]
+    spatial_pattern = (
+        np.sin(np.radians(lat))[:, None, None]
+        * np.cos(np.radians(lon))[None, :, None]
     )
+
+    noise = np.random.randn(nlat, nlon, len(time))
+
+    if variable in ["tas", "tasmax", "tasmin"]:
+        # --- temperature base (Kelvin) ---
+        tas_base = 288 + 12 * spatial_pattern + 8 * seasonal_cycle
+        tas = tas_base + noise * 2
+
+        # ensure consistency
+        tasmin = tas - (3 + np.abs(np.random.randn(*tas.shape)))
+        tasmax = tas + (3 + np.abs(np.random.randn(*tas.shape)))
+
+        if variable == "tas":
+            data = tas
+            units = "K"
+
+        elif variable == "tasmin":
+            data = tasmin
+            units = "K"
+
+        elif variable == "tasmax":
+            data = tasmax
+            units = "K"
+
+    elif variable == "pr":
+        # precipitation flux (kg m-2 s-1)
+        base = 1e-5 * (spatial_pattern + 1.5)  # wetter tropics
+        variability = np.abs(noise) * 2e-5
+        data = base + variability
+        units = "kg m-2 s-1"
+
+    elif variable == "sfcWind":
+        data = 2 + 2 * spatial_pattern + np.abs(noise) * 2
+        units = "m s-1"
+
+    elif variable == "rsds":
+        data = 200 + 150 * seasonal_cycle + 50 * spatial_pattern + noise * 20
+        units = "W m-2"
+
+    else:
+        raise ValueError(f"Unsupported variable: {variable}")
 
     attrs = {
         'name': '/ccc/work/cont003/gencmip6/checagar/IGCM_OUT/IPSLCM6/PROD/'
@@ -1894,7 +1940,7 @@ def generate_fake_cmip6_data(ntime=1, nlat=180, nlon=360, freq='D'):
         'experiment': 'all-forcing simulation of the recent past',
         'external_variables': 'areacella',
         'forcing_index': np.int32(1),
-        'frequency': 'day',
+        # 'frequency': 'day',
         'further_info_url': 'https://furtherinfo.es-doc.org/CMIP6.IPSL.IPSL-'
                             'CM6A-LR-INCA.historical.none.r1i1p1f1',
         'grid': 'LMDZ grid',
@@ -1960,7 +2006,13 @@ def generate_fake_cmip6_data(ntime=1, nlat=180, nlon=360, freq='D'):
 
     ds = xr.Dataset(
         {
-            "tas": (["lat", "lon", "time"], temperature),
+            variable: (
+                ["lat", "lon", "time"],
+                data,
+                {
+                    "units": units,
+                }
+            )
         },
         coords={
             "lat": lat,
@@ -1969,6 +2021,10 @@ def generate_fake_cmip6_data(ntime=1, nlat=180, nlon=360, freq='D'):
         },
         attrs=attrs,
     )
+
+    ds = ds.pyku.to_cmor_units()
+    ds = ds.pyku.to_cmor_attrs()
+    ds = ds.pyku.reorder_dimensions_and_coordinates()
 
     return ds
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ line-length = 80
 [project]
 name = "pyku"
 description = "pyku"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version"]
 readme = "README.md"
 authors = [
@@ -43,7 +43,7 @@ dependencies = [
     "geopandas",
     "h5netcdf",
     "h5py",
-    "jsonargparse==4.40",
+    "jsonargparse",
     "matplotlib",
     "metpy",
     "nbconvert",

--- a/testing/clix_test.py
+++ b/testing/clix_test.py
@@ -1,0 +1,64 @@
+import importlib.resources
+import yaml
+
+from pyku.resources import generate_fake_cmip6_data
+
+import xarray as xr
+
+from pyku.clix.manager import ClimateIndicator
+from pyku.clix.custom_indicators import (
+    expand_percentiles_to_daily,
+    percentile_grouped
+)
+
+from xclim.core.calendar import percentile_doy
+
+def calc_indicator(indicator_name, frequency, data):
+
+    # Define parameters (use an empty dictionary for default indicator setup)
+    params = {}   
+    clind = ClimateIndicator(indicator_name, frequency)
+    
+    if clind.is_perc_indicator:
+        req_args = data.copy()
+        for varname, da in data.items():
+            arr_perc = percentile_grouped(
+                    da,
+                    group_freq=frequency,
+                    per=95.,
+                    climatology=True
+                )
+            arr_perc = expand_percentiles_to_daily(da, arr_perc, frequency)
+        req_args[f'{varname}_per'] = arr_perc
+    else:
+        req_args = data
+
+    clind.required_args = req_args
+    result = clind()
+        
+    return result
+
+# Load indicator yaml data
+# ------------------------
+
+indicator_file = importlib.resources.files(
+    'pyku.etc') / 'climate_indicators.yaml'
+
+with open(indicator_file) as f:
+    grouped_indicator_data = yaml.safe_load(f)
+
+# Derive dictionary with variables as keys and list of indicator names
+indicator_data = {
+    group: list(indicators.keys())
+    for group, indicators in grouped_indicator_data.items()
+}
+
+for varnames, indicators in indicator_data.items():
+    data = {}
+    #print(f'Variable(s) to use for caculation: {', '.join(varnames.split('+'))}')
+    for varname in varnames.split('+'):
+        data[varname] = generate_fake_cmip6_data(
+            variable=varname, ntime=2, nlat=1, nlon=1, freq='D')[varname]
+    for indicator_name in indicators:
+        #print(indicator_name)
+        calc_indicator(indicator_name, 'YS', data)


### PR DESCRIPTION
I have put some effort in cleaning up our `climate_indicators.yaml` file and include a small code snippet for testing all indicators using fake data, that are generated on the fly using the `generate_fake_cmip6 function`. In this case I have extended this function mentioned in order to have different data for different variables.