### PR TITLE
Maintenance of HYRAS geographic projection data

### DIFF
--- a/definitions/projections/HYR-LAEA.ipynb
+++ b/definitions/projections/HYR-LAEA.ipynb
@@ -205,7 +205,7 @@
     "    crs_name: crs\n",
     "    crs_data:\n",
     "        grid_mapping_name: 'lambert_azimuthal_equal_area'\n",
-    "        longitude_of_central_meridian: 10.0\n",
+    "        longitude_of_projection_origin: 10.0\n",
     "        latitude_of_projection_origin: 52.0\n",
     "        semi_major_axis: 6378137.0\n",
     "        semi_minor_axis: 6356752.31414036\n",
@@ -279,11 +279,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "pyku_dev",
-   "language": "python",
-   "name": "pyku_dev"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -294,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/definitions/projections/RADKLIM_RADOLAN.ipynb
+++ b/definitions/projections/RADKLIM_RADOLAN.ipynb
@@ -153,9 +153,9 @@
    "source": [
     "CF-conform projection informations\n",
     "\n",
-    "This is done by hand\n",
+    "This is done by hand from\n",
     "\n",
-    "https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/apf.html"
+    "https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.pdf"
    ]
   },
   {
@@ -167,8 +167,9 @@
    "source": [
     "cf_projection_definition = {\n",
     "    'grid_mapping_name': 'polar_stereographic',\n",
-    "    'standard_parallel': 60,\n",
-    "    'straight_vertical_longitude_from_pole': 10.0,\n",
+    "    'latitude_of_projection_origin': 90.0,\n",
+    "    'longitude_of_projection_origin': 10.0,\n",
+    "    'standard_parallel': 60.0,\n",
     "    'earth_radius': 6370040.0,\n",
     "    'false_easting': 0.0,\n",
     "    'false_northing': 0.0,\n",
@@ -941,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/pyku/etc/areas_cf.yaml
+++ b/pyku/etc/areas_cf.yaml
@@ -39,8 +39,9 @@ DWD_RADOLAN_900x900:
     crs_data:
         grid_mapping_name: polar_stereographic
         long_name: RADOLAN Grid
-        standard_parallel: 60
-        straight_vertical_longitude_from_pole: 10.0
+        latitude_of_projection_origin: 90.0
+        longitude_of_projection_origin: 10.0
+        standard_parallel: 60.0
         earth_radius: 6370040.0
         false_easting: 0.0
         false_northing: 0.0
@@ -55,8 +56,9 @@ DWD_RADOLAN_1100x900:
     crs_data:
         grid_mapping_name: polar_stereographic
         long_name: RADOLAN Grid
-        standard_parallel: 60
-        straight_vertical_longitude_from_pole: 10.0
+        latitude_of_projection_origin: 90.0
+        longitude_of_projection_origin: 10.0
+        standard_parallel: 60.0
         earth_radius: 6370040.0
         false_easting: 0.0
         false_northing: 0.0
@@ -72,6 +74,7 @@ HYR-LCC-1:
         grid_mapping_name: lambert_conformal_conic
         long_name: DWD HYRAS ETRS89 LCC grid with 1200 columns and 100 rows
         standard_parallel: [35.0, 65.0]
+        latitude_of_projection_origin: 90.0
         longitude_of_central_meridian: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0

--- a/pyku/etc/areas_cf.yaml
+++ b/pyku/etc/areas_cf.yaml
@@ -150,7 +150,7 @@ HYR-LAEA-1:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -164,10 +164,11 @@ HYR-LAEA-1:
         epsg_code: 'EPSG:3035'
         long_name: 'DWD HYRAS ETRS89 LAEA grid with 1290 columns and 1100 rows'
 
+HYR-LAEA-2:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -185,7 +186,7 @@ HYR-LAEA-3:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -203,7 +204,7 @@ HYR-LAEA-5:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -221,7 +222,7 @@ HYR-LAEA-12.5:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -239,7 +240,7 @@ HYR-LAEA-50:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -257,7 +258,7 @@ HYR-LAEA-100:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -275,7 +276,7 @@ HYR-GER-LAEA-1:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -293,7 +294,7 @@ HYR-GER-LAEA-2:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -311,7 +312,7 @@ HYR-GER-LAEA-3:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -329,7 +330,7 @@ HYR-GER-LAEA-5:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -347,7 +348,7 @@ HYR-GER-LAEA-12.5:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -365,7 +366,7 @@ HYR-GER-LAEA-50:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036
@@ -383,7 +384,7 @@ HYR-GER-LAEA-100:
     crs_name: crs
     crs_data:
         grid_mapping_name: 'lambert_azimuthal_equal_area'
-        longitude_of_central_meridian: 10.0
+        longitude_of_projection_origin: 10.0
         latitude_of_projection_origin: 52.0
         semi_major_axis: 6378137.0
         semi_minor_axis: 6356752.31414036

--- a/pyku/geo.py
+++ b/pyku/geo.py
@@ -16,7 +16,6 @@ https://cordex.org/domains/
 
 from pyku import PYKU_RESOURCES, logger
 
-
 # Define projections which are deprecated. This should be removed in a later
 # version of pyku
 
@@ -104,8 +103,9 @@ def load_area_def(projection_name, area_file=None):
               ...: geo.load_area_def('HYR-LAEA-5')
     """
 
-    import warnings
     import importlib
+    import warnings
+
     from pyresample.area_config import load_area
 
     warnings.filterwarnings(
@@ -143,8 +143,9 @@ def align_georeferencing(ds, ref, tolerance=None):
         reference dataset.
     """
 
-    import pyku.meta as meta
     import numpy as np
+
+    from pyku import meta
 
     # Get projection x/y and geographic lat/lon names
     # -----------------------------------------------
@@ -197,8 +198,8 @@ def align_georeferencing(ds, ref, tolerance=None):
     is_meter = (
         x_name_units_ref is not None
         and y_name_units_ref is not None
-        and x_name_units_ref.lower() in ['m']
-        and y_name_units_ref.lower() in ['m']
+        and x_name_units_ref.lower() == 'm'
+        and y_name_units_ref.lower() == 'm'
     )
 
     # Set tolerance to defaults depending on unit
@@ -302,7 +303,7 @@ def get_ny(ds):
               ...: ds.pyku.get_ny()
     """
 
-    import pyku.meta as meta
+    from pyku import meta
 
     y_name, x_name = meta.get_projection_yx_varnames(ds)
 
@@ -651,9 +652,10 @@ def get_yx(ds, dtype='ndarray'):
             coordinates are found in the dataset, ``None`` is returned.
     """
 
-    import xarray as xr
     import numpy as np
-    import pyku.meta as meta
+
+    import xarray as xr
+    from pyku import meta
 
     # Get geographic latlon names
     # ---------------------------
@@ -672,13 +674,13 @@ def get_yx(ds, dtype='ndarray'):
     # Return tuple of numpy ndarrays
     # ------------------------------
 
-    if dtype in ['ndarray']:
+    if dtype == 'ndarray':
         return ys2d, xs2d
 
     # Return xarray Dataset
     # ---------------------
 
-    elif dtype in ['xr.Dataset']:
+    elif dtype == 'xr.Dataset':
 
         # Create DataArrays containing lons and lats
         # ------------------------------------------
@@ -728,8 +730,9 @@ def get_yx_area_extent(ds):
         tuple: (lower_left_x, lower_left_y, upper_right_x, upper_right_y)
     """
 
-    import pyku.meta as meta
     import pyresample.utils
+
+    from pyku import meta
 
     # Get y and x projection coordinate variable names
     y_varname, x_varname = meta.get_projection_yx_varnames(ds)
@@ -777,17 +780,16 @@ def get_lonlats(ds, dtype='ndarray'):
               ...: ds.pyku.get_lonlats()
     """
 
-    import xarray as xr
     import numpy as np
-    import pyku.meta as meta
+
+    import xarray as xr
+    from pyku import meta
 
     # Sanity check
     # ------------
 
-    is_dataset_or_dataarray = (
-        isinstance(ds, xr.Dataset)
-        or isinstance(ds, xr.DataArray)
-    )
+    is_dataset_or_dataarray = isinstance(ds, (xr.Dataset, xr.DataArray))
+
     if not is_dataset_or_dataarray:
         raise TypeError(f"Not a Dataset or DataArray {type(ds)}")
 
@@ -817,11 +819,11 @@ def get_lonlats(ds, dtype='ndarray'):
     lons = ds.coords[lon_name].to_numpy()
     lats = ds.coords[lat_name].to_numpy()
 
-    if ds[lon_name].attrs.get('units') in ['radian']:
+    if ds[lon_name].attrs.get('units') == 'radian':
         logger.warning('longitude unit conversion from radians to degrees')
         lons = np.degrees(lons)
 
-    if ds[lat_name].attrs.get('units') in ['radian']:
+    if ds[lat_name].attrs.get('units') == 'radian':
         logger.warning('latitude unit conversion from radians to degrees')
         lats = np.degrees(lats)
 
@@ -867,13 +869,13 @@ def get_lonlats(ds, dtype='ndarray'):
     # Return tuple of numpy ndarrays
     # ------------------------------
 
-    if dtype in ['ndarray']:
+    if dtype == 'ndarray':
         return lons, lats
 
     # Return xarray Dataset
     # ---------------------
 
-    elif dtype in ['xr.Dataset']:
+    elif dtype == 'xr.Dataset':
 
         # Create DataArrays containing lons and lats
         # ------------------------------------------
@@ -933,7 +935,8 @@ def set_latlon_bounds(ds):
     """
 
     import cf_xarray  # noqa, this library defines the cf namespace
-    import pyku.meta as meta
+
+    from pyku import meta
 
     ds_out = ds.copy()
 
@@ -980,8 +983,9 @@ def get_area_at_true_scale(ds):
 
     import numpy as np
     import pyproj
-    import pyku.meta as meta
     from pyproj import Geod
+
+    from pyku import meta
 
     # Initialize the Geod object with WGS84 ellipsoid
     # -----------------------------------------------
@@ -1091,8 +1095,8 @@ def get_area_at_true_scale(ds):
     is_meter = (
         x_name_units_ref is not None
         and y_name_units_ref is not None
-        and x_name_units_ref.lower() in ['m']
-        and y_name_units_ref.lower() in ['m']
+        and x_name_units_ref.lower() == 'm'
+        and y_name_units_ref.lower() == 'm'
     )
 
     # Set tolerance to defaults depending on unit
@@ -1234,10 +1238,11 @@ def set_spatial_weights(ds, how='area'):
     #   Since the true scale can be located outside the map, a 'virtual' grid
     #   cell is constructed at true scale and its area calculated.
 
-    import xarray as xr
     import numpy as np
-    import pyku.meta as meta
     from pyproj import Geod
+
+    import xarray as xr
+    from pyku import meta
 
     out_ds = ds.copy()
 
@@ -1421,8 +1426,9 @@ def are_longitudes_wrapped(ds):
               ...: ds.pyku.are_longitudes_wrapped()
     """
 
-    import pyku.meta as meta
     import numpy as np
+
+    from pyku import meta
 
     lat_name, lon_name = meta.get_geographic_latlon_varnames(ds)
 
@@ -1464,8 +1470,8 @@ def wrap_longitudes(ds):
               ...: ds.pyku.wrap_longitudes()
     """
 
-    import pyku.meta as meta
     import xarray as xr
+    from pyku import meta
 
     if (
         not meta.has_geographic_coordinates(ds) or
@@ -1538,7 +1544,7 @@ def is_georeferencing_sorted(ds):
               ...: ds.pyku.is_georeferencing_sorted()
     """
 
-    import pyku.meta as meta
+    from pyku import meta
 
     if not meta.has_projection_coordinates(ds):
         raise AssertionError("Dataset must have projection coordinates!")
@@ -1580,7 +1586,7 @@ def are_yx_projection_coordinates_strictly_monotonic(ds):
               ...: ds.pyku.are_yx_projection_coordinates_strictly_monotonic()
     """
 
-    import pyku.meta as meta
+    from pyku import meta
 
     # For unstructured geographic coordinates (e.g., ICON grid), monotonicity
     # is not applicable; returning True by default.
@@ -1671,7 +1677,7 @@ def sort_georeferencing(ds):
     """
 
     import xarray as xr
-    import pyku.meta as meta
+    from pyku import meta
 
     # Keep attributes during operations
     # ---------------------------------
@@ -1730,8 +1736,9 @@ def _get_area_def_from_global_attrs(ds):
         :class:`pyresample.geometry.AreaDefinition`: The area definition.
     """
 
-    import pyku.meta as meta
     from pyresample.geometry import AreaDefinition
+
+    from pyku import meta
 
     # Read the projection parameters from the global attributes
     # ---------------------------------------------------------
@@ -1779,7 +1786,7 @@ def _get_area_def_from_crs_proj_str(ds):
         :class:`pyresample.geometry.AreaDefinition`: The area definition.
     """
 
-    import pyku.meta as meta
+    from pyku import meta
     from pyresample.geometry import AreaDefinition
 
     try:
@@ -2047,8 +2054,9 @@ def select_neighborhood(
 
     import numpy as np
     import pandas as pd
-    import pyku.meta as meta
     from pyresample import geometry, kd_tree
+
+    from pyku import meta
 
     # Get the source area definition
     # ------------------------------
@@ -2159,8 +2167,8 @@ def _resampling_nearest_from_swath_to_grid(
         :class:`dask.Array`: Resampled dask array
     """
 
-    import numpy as np
     import dask
+    import numpy as np
     from pyresample import kd_tree
 
     logger.warning('Experimental function')
@@ -2254,8 +2262,8 @@ def _resampling_idw_from_swath_to_swath(
         :class:`dask.Array`: Resampled dask array
     """
 
-    import numpy as np
     import dask
+    import numpy as np
     from pyresample import kd_tree
 
     def block_resampling(arr):
@@ -2329,8 +2337,8 @@ def _resampling_nearest_from_swath_to_swath(
         :class:`dask.Array`: Resampled dask array
     """
 
-    import numpy as np
     import dask
+    import numpy as np
     from pyresample import kd_tree
 
     # source_swath.lons=np.pad(source_swath.lons, 1, mode='edge')
@@ -2397,8 +2405,8 @@ def _resampling_nearest_from_swath_to_swath_legacy(
         :class:`dask.Array`: Resampled dask array
     """
 
-    import numpy as np
     import dask
+    import numpy as np
     from pyresample.image import ImageContainerNearest
     from pyresample.utils import generate_nearest_neighbour_linesample_arrays
 
@@ -2465,13 +2473,12 @@ def _resampling_bilinear_from_swath_to_swath_legacy(
         :class:`dask.Array`: Resampled dask array
     """
 
-    import warnings
-    import numpy as np
     import dask
+    import numpy as np
     from pyresample.image import ImageContainerBilinear
     from pyresample.utils import generate_nearest_neighbour_linesample_arrays
 
-    warnings.warn("Using legacy bilinear resampling from swath to swath")
+    logger.warning("Using legacy bilinear resampling from swath to swath")
 
     row_indices, col_indices = generate_nearest_neighbour_linesample_arrays(
         source_swath,
@@ -2540,8 +2547,9 @@ def _resampling_bilinear_from_swath_to_grid(
         since it already implements block resampling in pyresample.
     """
 
-    import pyku.meta as meta
     from pyresample.bilinear import XArrayBilinearResampler
+
+    from pyku import meta
 
     # The function XArrayBilinearResampler only needs y and x projection
     # coordinates dimension name but these shall be named 'y' and 'x'
@@ -2594,8 +2602,8 @@ def _resampling_bilinear_from_swath_to_grid_legacy(
         dask.Array: Resampled dask array.
     """
 
-    import numpy as np
     import dask
+    import numpy as np
     from pyresample.image import ImageContainerBilinear
 
     def block_resampling(arr):
@@ -2787,17 +2795,15 @@ def project(
     # complexity but is being kept at the moment.
 
     import copy
-    import pyku.meta as meta
-    import pyku.drs as drs
-    import pyku.features as features
-    import pyku.mask as mask
-    import xarray as xr
+
+    import dask.array as dk
     import numpy as np
     import pyresample
-    from pyresample import geometry
-    import pyku.geo as geo
-    import dask.array as dk
     from pyproj import CRS, Transformer
+    from pyresample import geometry
+
+    import xarray as xr
+    from pyku import drs, features, mask, meta
 
     # Shallow copy the input and rename for clarity
     # ---------------------------------------------
@@ -2828,13 +2834,13 @@ def project(
         'conservative'
     ]
 
-    if method in ['nearest_neighbor']:
+    if method == 'nearest_neighbor':
         method = 'pyresample_nearest_neighbor'
-    if method in ['bilinear']:
+    if method == 'bilinear':
         method = 'pyresample_bilinear'
-    if method in ['idw']:
+    if method == 'idw':
         method = 'pyresample_idw'
-    if method in ['conservative']:
+    if method == 'conservative':
         method = 'esmf_conservative'
 
     # Get target area definition
@@ -2906,14 +2912,14 @@ def project(
             "ds.pyku.get_area_def() to extract the area definition instead"
         )
 
-    if method in ['idw'] and power_parameter is None:
+    if method == 'idw' and power_parameter is None:
         raise AssertionError(
             "`power_parameter` must be passed for IDW resampling"
         )
 
     if (
-        method in ['bilinear'] and
-        out_area_def.proj_dict.get('proj') in ['ob_tran']
+        method == 'bilinear' and
+        out_area_def.proj_dict.get('proj') == 'ob_tran'
     ):
         raise Exception(
             "Rotated lat/lon is not supported for the default "
@@ -2968,7 +2974,7 @@ def project(
     # Get source geographic lat/lon coordinates
     # -----------------------------------------
 
-    in_lons, in_lats = geo.get_lonlats(in_ds)
+    in_lons, in_lats = get_lonlats(in_ds)
 
     # Get source y/x projection and lat/lon geographic coordinate names
     # -----------------------------------------------------------------
@@ -3088,7 +3094,7 @@ def project(
 
             out_arr = out_da.data
 
-        elif method in ['pyresample_nearest_neighbor']:
+        elif method == 'pyresample_nearest_neighbor':
 
             out_arr = _resampling_nearest_from_swath_to_swath(
                 in_arr,
@@ -3099,7 +3105,7 @@ def project(
                 use_dask=use_dask,
             )
 
-        elif method in ['pyresample_idw']:
+        elif method == 'pyresample_idw':
 
             out_arr = _resampling_idw_from_swath_to_swath(
                 in_arr,
@@ -3120,17 +3126,17 @@ def project(
             'esmf_nearest_d2s',
         ]:
 
-            if method in ['esmf_bilinear']:
+            if method == 'esmf_bilinear':
                 method = 'bilinear'
-            if method in ['esmf_conservative']:
+            if method == 'esmf_conservative':
                 method = 'conservative'
-            if method in ['esmf_conservative_normed']:
+            if method == 'esmf_conservative_normed':
                 method = 'conservative_normed'
-            if method in ['esmf_patch']:
+            if method == 'esmf_patch':
                 method = 'patch'
-            if method in ['esmf_nearest_s2d']:
+            if method == 'esmf_nearest_s2d':
                 method = 'nearest_s2d'
-            if method in ['esmf_nearest_d2s']:
+            if method == 'esmf_nearest_d2s':
                 method = 'nearest_d2s'
 
             # Raise exception if xesmf is not installed
@@ -3197,7 +3203,7 @@ def project(
 
             out_arr = out_da.data
 
-        elif method in ['pyresample_bilinear_swath_to_grid']:
+        elif method == 'pyresample_bilinear_swath_to_grid':
 
             out_da = _resampling_bilinear_from_swath_to_grid(
                 in_da,
@@ -3214,7 +3220,7 @@ def project(
 
             out_arr = out_da.data
 
-        elif method in ['pyresample_bilinear_swath_to_grid_legacy']:
+        elif method == 'pyresample_bilinear_swath_to_grid_legacy':
 
             out_arr = _resampling_bilinear_from_swath_to_grid_legacy(
                 in_arr,
@@ -3225,7 +3231,7 @@ def project(
                 use_dask=use_dask,
             )
 
-        elif method in ['pyresample_bilinear_swath_to_swath_legacy']:
+        elif method == 'pyresample_bilinear_swath_to_swath_legacy':
 
             out_arr = _resampling_bilinear_from_swath_to_swath_legacy(
                 in_arr,
@@ -3236,7 +3242,7 @@ def project(
                 use_dask=use_dask,
             )
 
-        elif method in ['pyresample_nearest_neighbor_legacy']:
+        elif method == 'pyresample_nearest_neighbor_legacy':
 
             out_arr = _resampling_nearest_from_swath_to_swath_legacy(
                 in_arr,
@@ -3407,7 +3413,7 @@ def project(
         # Rename x and y coordinates if necessary
         # ---------------------------------------
 
-        if x_name not in ['x'] and y_name not in ['y']:
+        if x_name != 'x' and y_name != 'y':
             out_ds = out_ds.rename({'x': x_name, 'y': y_name})
 
         # Set CMOR-conform coordinate attributes


### PR DESCRIPTION
## Summary

This merge request corrects an invalid CF-Standard attribute name for the Lambert Azimuthal Equal Area projection (`HYRAS` projections) and updates module styling to align with upcoming linting standards.

## Changes

### 1. Fix CF-Standard Compliance in `area_cf.yml`
* **Issue:** The attribute `longitude_of_central_meridian` does not comply with the CF-Standard for `lambert_azimuthal_equal_area`.
* **Fix:** Updated the attribute name to `longitude_of_projection_origin` per the [CF-Conventions (page 157)](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.pdf).

### 2. Code Style Updates (`geo` module)
* Refactored the `geo` module to follow the upcoming `pyku` convention (which closely mirrors the `xarray` Ruff configuration). 
* This prepares the codebase for a future transition to the Ruff linter.